### PR TITLE
Fix holiday interval being read as minutes

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -563,6 +563,14 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 )
             )
 
+        def get_interval_hours(option_key, default_interval):
+            """Retrieve interval in hours from options or fallback to default."""
+            return timedelta(
+                hours=options.get(
+                    option_key, int(default_interval.total_seconds() / 3600)
+                )
+            )
+
         def get_delay(option_key, default_interval):
             """Retrieve delay in seconds from options or fallback to default."""
             return timedelta(
@@ -653,7 +661,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             "enable_shutdown_refresh_sequence", self.enable_shutdown_refresh_sequence
         )
         self.holiday_mode = options.get("holiday_mode", self.holiday_mode)
-        self.holiday_update_interval = get_interval(
+        self.holiday_update_interval = get_interval_hours(
             CONF_HOLIDAY_UPDATE_INTERVAL, self.holiday_update_interval
         )
         self.stale_data_threshold = timedelta(


### PR DESCRIPTION
The holiday interval value set in the integration settings gets incorrectly read as minutes, as can be seen in the "Last Update Time" sensor value.
This PR introduces a new "get_interval_hours" helper function to the "async_update_options" function, to read the config value as hours.