### PR TITLE
chore(india): bump client to 0.1.4

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.3"
+    "mg-ismart-india-client==0.1.4"
   ],
   "version": "1.2.4-beta1"
 }


### PR DESCRIPTION
Pins the released mg-ismart-india-client 0.1.4 package. This is deliberately separate from the GPS adapter changes in #289 so dependency publication and integration behavior remain independently reviewable.