### PR TITLE
Release 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,6 @@ The [`tools/`](tools/) folder contains optional helper scripts for **researching
  
 | File | Purpose |
 |------|---------|
-| `saic_intercept.py` | A [mitmproxy](https://mitmproxy.org/) addon that decrypts the iSmart app's traffic locally (requests and responses) and logs it as readable JSON. |
 | `redact.py` | Strips your login token and sensitive headers from a capture **before** you share it — always run this first. |
  
 These scripts only *observe* app traffic; they do not modify your car, account, or the integration. See [`tools/README.md`](tools/README.md) for the full walkthrough. If you'd like to help profile your model, contributions of captured (redacted) data are very welcome.

--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
 | `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |
 | `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | Battery capacity 24.7 kWh; Target SOC and Charging Current Limit not supported by iSmart; electric range uses live SOC-tracking field; energy values corrected for ~3x API over-reporting |
+| `S12L` | IM6 (IM by MG Motor) | Battery capacity 100 kWh — corrects the API's bogus `totalBatteryCapacity=725` (→ 72.5 kWh) for the Platinum/Performance pack (#53). ⚠️ Confirmed on the 100 kWh Platinum; if the 75 kWh LFP Premium reports the same series, this will need splitting — Premium owners, please open an issue with debug logs |
  
 Models not listed above use safe default values and should work normally. If you notice incorrect sensor readings for your model, please open an issue with your vehicle's debug logs.
  

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -88,14 +88,17 @@ def _gps_position(gps):
     so convert back into that convention rather than teaching every consumer
     a second shape.
 
-    Those consumers do arithmetic on wayPoint's fields without guarding each
-    hop, but they all skip the block entirely when wayPoint is None. So the
-    wayPoint is built only when there are real coordinates to put in it, and
-    heading and speed fall back to 0 (a stationary car) rather than None.
+    Those consumers skip the block entirely when wayPoint is None. Build it
+    only for a usable fix with both coordinates while retaining the status
+    metadata for diagnostics when there is no fix.
     """
     latitude = _micro_degrees(getattr(gps, "latitude", None))
     longitude = _micro_degrees(getattr(gps, "longitude", None))
-    if latitude is None or longitude is None:
+    if (
+        not getattr(gps, "has_fix", False)
+        or latitude is None
+        or longitude is None
+    ):
         way_point = None
     else:
         way_point = _ns(
@@ -104,8 +107,8 @@ def _gps_position(gps):
                 longitude=longitude,
                 altitude=getattr(gps, "altitude_m", None),
             ),
-            heading=getattr(gps, "heading_deg", None) or 0,
-            speed=_tenths(getattr(gps, "speed_kmh", None)) or 0,
+            heading=getattr(gps, "heading_deg", None),
+            speed=_tenths(getattr(gps, "speed_kmh", None)),
             hdop=getattr(gps, "hdop", None),
             satellites=getattr(gps, "satellites", None),
         )

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -58,6 +58,54 @@ def _raw_basic(status, key: str, default=None):
     return default
 
 
+def _micro_degrees(value: float | None) -> int | None:
+    if value is None:
+        return None
+    return int(round(float(value) * 1_000_000))
+
+
+def _gps_position(gps):
+    """Map a decoded India GpsPosition onto the SAIC GpsPosition shape.
+
+    The device tracker, the speed sensor and the ABRP sender all read the
+    position through the EU/global protocol's own layout and units: a nested
+    wayPoint/position, coordinates in micro-degrees, speed in tenths of a
+    km/h. mg-ismart-india-client hands over already-decoded degrees and km/h,
+    so convert back into that convention rather than teaching every consumer
+    a second shape.
+
+    Those consumers do arithmetic on wayPoint's fields without guarding each
+    hop, but they all skip the block entirely when wayPoint is None. So the
+    wayPoint is built only when there are real coordinates to put in it, and
+    heading and speed fall back to 0 (a stationary car) rather than None.
+    """
+    latitude = _micro_degrees(getattr(gps, "latitude", None))
+    longitude = _micro_degrees(getattr(gps, "longitude", None))
+    if latitude is None or longitude is None:
+        way_point = None
+    else:
+        way_point = _ns(
+            position=_ns(
+                latitude=latitude,
+                longitude=longitude,
+                altitude=getattr(gps, "altitude_m", None),
+            ),
+            heading=getattr(gps, "heading_deg", None) or 0,
+            speed=_tenths(getattr(gps, "speed_kmh", None)) or 0,
+            hdop=getattr(gps, "hdop", None),
+            satellites=getattr(gps, "satellites", None),
+        )
+    # GpsStatus is an IntEnum whose names and values match the SAIC schema's,
+    # so it can stand in for the decoded status the ABRP sender looks for.
+    status = getattr(gps, "gps_status", None)
+    return _ns(
+        wayPoint=way_point,
+        gpsStatus=getattr(status, "value", None),
+        gps_status_decoded=status,
+        timeStamp=getattr(gps, "position_time", None),
+    )
+
+
 def _vehicle_config(vehicle, code: str, default=None):
     raw = getattr(vehicle, "raw", None)
     if isinstance(raw, dict):
@@ -246,7 +294,7 @@ class IndiaBackend:
         return _ns(
             statusTime=timestamp,
             basicVehicleStatus=basic,
-            gpsPosition=_ns(speed=_raw_basic(status, "speed")),
+            gpsPosition=_gps_position(getattr(status, "gps", None)),
             raw=getattr(status, "raw", None),
         )
 

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -517,6 +517,61 @@ VEHICLE_PROFILES = {
         # DATA_DECIMAL_CORRECTION — see SAICMGChargingSensor for usage.
         "charging_capacity_correction": 1 / 3,
     },
+    "S12L": {  # IM6 (IM Motors, "IM presented by MG Motor") — BEV SUV. See Discussion #53.
+        # Reported by mstobie (#53): IM6 Platinum (BEV), Australia, series 'S12L'.
+        # The Total Battery Capacity sensor showed 72.5 kWh, but the Platinum has a
+        # 100 kWh pack. Root cause: the API returns totalBatteryCapacity=725, which
+        # the ×0.1 factor turns into 72.5 kWh. That 725 is a known-bogus SAIC
+        # placeholder — the SAME 725 shows up on the Cyberster (EC32) and the HS PHEV
+        # (AS33P), and another owner reported the identical 72.5 on an MG4 — so it
+        # cannot be trusted as a real capacity here. Override it with the known pack
+        # size instead (matching the existing EC32/AS33P handling of the same value).
+        #
+        # IM6 battery options (MG Australia spec sheet): 75 kWh LFP (Premium, 400V
+        # IGBT platform) and 100 kWh NCM (Platinum & Performance, 800V SiC platform).
+        # mstobie's car is the Platinum → 100 kWh. Independent cross-check from the
+        # SAME log: bmsPackVol=3088 × CHARGING_VOLTAGE_FACTOR (0.25) ≈ 772 V — an
+        # 800V-class pack, consistent with the 100 kWh NCM Platinum/Performance and
+        # NOT the 400V Premium.
+        #
+        # ⚠ TRIM CAVEAT: it is not yet confirmed whether the 75 kWh Premium reports
+        # the same 'S12L' series or a different one — no Premium log has been seen. If
+        # a Premium turns out to also match 'S12L', this 100 kWh value would be wrong
+        # for it, and this entry must then be split by a better discriminator (e.g.
+        # the ~400V vs ~772V pack voltage noted above, or a distinct series/config
+        # code once a Premium log is available). Until then it is scoped to the
+        # confirmed Platinum/Performance figure. Note the Premium is already shown the
+        # wrong 72.5 kWh today, so this override does not make any Premium worse — it
+        # only corrects the 100 kWh cars. Total Battery Capacity is a display-only
+        # sensor and drives no control logic, so the blast radius is a single number.
+        #
+        # 100.0 is the nominal/pack figure — matches the owner's expectation, the
+        # marketed spec, and the "Total Battery Capacity" sensor name (same convention
+        # as the MGS5's 64.0 pack figure).
+        #
+        # Everything below mirrors DEFAULT_VEHICLE_PROFILE, which is what the IM6 used
+        # while unprofiled — so the ONLY behavioural change for this car is the battery
+        # capacity. IM6 climate has not been tested; leave it at the safe defaults
+        # (fan_speed scheme, fan bytes limited to 1/2/3) until an owner reports back.
+        "min_temp": 16,
+        "max_temp": 28,
+        "temp_offset": 2,
+        "battery_capacity_kwh": 100.0,
+        "climate_status_cool": {3},
+        "climate_status_fan_only": {2},
+        "fan_speed_low": 1,
+        "fan_speed_medium": 2,
+        "fan_speed_high": 3,
+        "temp_idx_inverted": False,
+        "supports_target_soc": True,
+        "supports_charging_current_limit": True,
+        "reliable_fuel_range_elec": True,
+        "charging_capacity_correction": None,
+        "model_year_override": None,
+        "has_rear_doors": True,
+        "has_rear_windows": True,
+        "climate_control_scheme": "fan_speed",
+    },
 }
 
 # Fallback profile used when the vehicle's series does not match any entry

--- a/custom_components/mg_saic/device_tracker.py
+++ b/custom_components/mg_saic/device_tracker.py
@@ -40,7 +40,7 @@ class SAICMGDeviceTracker(CoordinatorEntity, TrackerEntity):
         # Store last known good coordinates
         self._last_lat = None
         self._last_lon = None
-        self._last_valid_heading = 0
+        self._last_valid_heading = None
 
     @property
     def unique_id(self):
@@ -139,7 +139,7 @@ class SAICMGDeviceTracker(CoordinatorEntity, TrackerEntity):
                 speed = gps_position.wayPoint.speed
                 heading = gps_position.wayPoint.heading
 
-                if speed > 1:
+                if speed is not None and heading is not None and speed > 1:
                     self._last_valid_heading = heading
                     return heading
                 elif self._last_valid_heading is not None:

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.3"
   ],
-  "version": "1.2.3"
+  "version": "1.2.4-beta1"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.3"
+    "mg-ismart-india-client==0.1.4"
   ],
   "version": "1.2.4-beta1"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.4"
   ],
-  "version": "1.2.4-beta2"
+  "version": "1.2.4"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.4"
   ],
-  "version": "1.2.4-beta1"
+  "version": "1.2.4-beta2"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2800,7 +2800,8 @@ class SAICMGVehicleSpeedSensor(CoordinatorEntity, SensorEntity):
                 gps = getattr(data, self._status_type, None)
                 if gps and gps.wayPoint:
                     speed = gps.wayPoint.speed
-                    return speed * self._factor if speed else 0
+                    if speed is not None:
+                        return speed * self._factor
         except AttributeError as e:
             LOGGER.error("Error retrieving speed for sensor '%s': %s", self._name, e)
         return None

--- a/tests/test_india_gps.py
+++ b/tests/test_india_gps.py
@@ -22,7 +22,10 @@ LOADED_MODULE_NAMES = (
     "homeassistant",
     "homeassistant.components",
     "homeassistant.components.device_tracker",
+    "homeassistant.components.sensor",
+    "homeassistant.const",
     "homeassistant.helpers",
+    "homeassistant.helpers.entity",
     "homeassistant.helpers.update_coordinator",
     "aiohttp",
     "mg_ismart_india_client",
@@ -32,7 +35,9 @@ LOADED_MODULE_NAMES = (
     f"{PACKAGE}.api",
     f"{PACKAGE}.backends",
     f"{PACKAGE}.backends.india",
+    f"{PACKAGE}.abrp",
     f"{PACKAGE}.device_tracker",
+    f"{PACKAGE}.sensor",
 )
 
 
@@ -83,9 +88,56 @@ def _load_modules():
         class _TrackerEntity:
             pass
 
+        class _SensorEntity:
+            pass
+
+        class _ClientTimeout:
+            def __init__(self, **_kwargs):
+                pass
+
+        class _Values:
+            BATTERY = "battery"
+            CURRENT = "current"
+            DIAGNOSTIC = "diagnostic"
+            DISTANCE = "distance"
+            DURATION = "duration"
+            ENERGY = "energy"
+            ENUM = "enum"
+            KILOMETERS = "km"
+            KILOMETERS_PER_HOUR = "km/h"
+            KILO_WATT = "kW"
+            KILO_WATT_HOUR = "kWh"
+            MINUTES = "min"
+            PERCENTAGE = "%"
+            POWER = "power"
+            PRESSURE = "pressure"
+            SPEED = "speed"
+            TEMPERATURE = "temperature"
+            TIMESTAMP = "timestamp"
+            VOLT = "V"
+            VOLTAGE = "voltage"
+
         _module(
             "homeassistant.components.device_tracker", TrackerEntity=_TrackerEntity
         )
+        _module(
+            "homeassistant.components.sensor",
+            SensorDeviceClass=_Values,
+            SensorEntity=_SensorEntity,
+        )
+        _module(
+            "homeassistant.const",
+            PERCENTAGE=_Values.PERCENTAGE,
+            UnitOfElectricPotential=_Values,
+            UnitOfEnergy=_Values,
+            UnitOfLength=_Values,
+            UnitOfPower=_Values,
+            UnitOfPressure=_Values,
+            UnitOfSpeed=_Values,
+            UnitOfTemperature=_Values,
+            UnitOfTime=_Values,
+        )
+        _module("homeassistant.helpers.entity", EntityCategory=_Values)
         _module(
             "homeassistant.helpers.update_coordinator",
             CoordinatorEntity=_CoordinatorEntity,
@@ -97,6 +149,23 @@ def _load_modules():
             f"{PACKAGE}.const",
             DOMAIN="mg_saic",
             LOGGER=logging.getLogger(PACKAGE),
+            ABRP_ME_URL="https://example.invalid/me",
+            ABRP_SEND_URL="https://example.invalid/send",
+            CHARGING_CURRENT_FACTOR=1,
+            CHARGING_VOLTAGE_FACTOR=1,
+            DATA_100_DECIMAL_CORRECTION=0.01,
+            DATA_DECIMAL_CORRECTION=0.1,
+            DATA_DECIMAL_CORRECTION_SOC=0.1,
+            DATA_FRESHNESS_CACHED="cached",
+            DATA_FRESHNESS_FAILED="failed",
+            DATA_FRESHNESS_LIVE="live",
+            MILEAGE_UINT16_SATURATION=65535,
+            PRESSURE_TO_BAR=0.04,
+            TEMP_SPIKE_BASE_TOLERANCE_C=5,
+            TEMP_SPIKE_MAX_RATE_C_PER_S=1,
+            VEHICLE_REACHABILITY_AWAKE="awake",
+            VEHICLE_REACHABILITY_LIKELY_ASLEEP="likely_asleep",
+            VEHICLE_REACHABILITY_UNREACHABLE="unreachable",
         )
         _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
 
@@ -108,6 +177,8 @@ def _load_modules():
 
         aiohttp = _module("aiohttp")
         aiohttp.ClientSession = object
+        aiohttp.ClientTimeout = _ClientTimeout
+        aiohttp.ClientError = Exception
 
         class _IndiaApiError(Exception):
             pass
@@ -131,7 +202,9 @@ def _load_modules():
         device_tracker = _load(
             f"{PACKAGE}.device_tracker", PKG_DIR / "device_tracker.py"
         )
-        return india, device_tracker
+        sensor = _load(f"{PACKAGE}.sensor", PKG_DIR / "sensor.py")
+        abrp = _load(f"{PACKAGE}.abrp", PKG_DIR / "abrp.py")
+        return india, device_tracker, sensor, abrp
     finally:
         for name in LOADED_MODULE_NAMES:
             if name in previous_modules:
@@ -140,7 +213,7 @@ def _load_modules():
                 sys.modules.pop(name, None)
 
 
-INDIA, DEVICE_TRACKER = _load_modules()
+INDIA, DEVICE_TRACKER, SENSOR, ABRP = _load_modules()
 
 
 def _client_gps(**overrides):
@@ -157,6 +230,12 @@ def _client_gps(**overrides):
         "position_time": 1_755_230_000,
     }
     values.update(overrides)
+    values.setdefault(
+        "has_fix",
+        values["gps_status"] in (_GpsStatus.FIX_2D, _GpsStatus.FIX_3D)
+        and values["latitude"] is not None
+        and values["longitude"] is not None,
+    )
     return SimpleNamespace(**values)
 
 
@@ -203,10 +282,40 @@ class IndiaGpsMappingTests(unittest.TestCase):
                 mapped = _india_status(self.backend, gps).gpsPosition
                 self.assertIsNone(mapped.wayPoint)
 
-    def test_absent_speed_and_heading_read_as_stationary(self):
-        # The consumers compare speed numerically without a None guard.
+    def test_no_fix_status_preserves_metadata_but_suppresses_coordinates(self):
+        cases = (
+            _client_gps(gps_status=_GpsStatus.NO_SIGNAL),
+            _client_gps(
+                gps_status=_GpsStatus.TIME_FIX, latitude=0.0, longitude=0.0
+            ),
+            _client_gps(has_fix=False),
+        )
+        for source in cases:
+            with self.subTest(status=source.gps_status, has_fix=source.has_fix):
+                mapped = _india_status(self.backend, source).gpsPosition
+                self.assertIsNone(mapped.wayPoint)
+                self.assertEqual(mapped.gpsStatus, source.gps_status.value)
+                self.assertIs(mapped.gps_status_decoded, source.gps_status)
+
+    def test_two_dimensional_fix_with_coordinates_is_usable(self):
+        gps = _india_status(
+            self.backend, _client_gps(gps_status=_GpsStatus.FIX_2D)
+        ).gpsPosition
+
+        self.assertEqual(gps.wayPoint.position.latitude, 12_971_599)
+        self.assertEqual(gps.wayPoint.position.longitude, 77_594_566)
+
+    def test_absent_speed_and_heading_remain_unknown(self):
         gps = _india_status(
             self.backend, _client_gps(speed_kmh=None, heading_deg=None)
+        ).gpsPosition
+
+        self.assertIsNone(gps.wayPoint.speed)
+        self.assertIsNone(gps.wayPoint.heading)
+
+    def test_zero_speed_and_heading_remain_numeric_zero(self):
+        gps = _india_status(
+            self.backend, _client_gps(speed_kmh=0, heading_deg=0)
         ).gpsPosition
 
         self.assertEqual(gps.wayPoint.speed, 0)
@@ -267,6 +376,134 @@ class IndiaDeviceTrackerTests(unittest.TestCase):
         self.assertIsNone(tracker.longitude)
         self.assertIsNone(tracker.elevation)
         self.assertEqual(tracker.extra_state_attributes, {})
+
+    def test_tracker_suppresses_no_fix_coordinates(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        status = _india_status(
+            backend, _client_gps(gps_status=_GpsStatus.NO_SIGNAL)
+        )
+        (tracker,) = self._setup_tracker(status)
+
+        self.assertIsNone(tracker.latitude)
+        self.assertIsNone(tracker.longitude)
+        self.assertEqual(tracker.extra_state_attributes, {})
+
+    def test_tracker_does_not_invent_heading_when_motion_is_unknown(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        status = _india_status(
+            backend, _client_gps(speed_kmh=None, heading_deg=None)
+        )
+        (tracker,) = self._setup_tracker(status)
+
+        self.assertIsNone(tracker.heading)
+        self.assertEqual(tracker.extra_state_attributes["heading"], "Unknown")
+        self.assertIsNone(tracker.extra_state_attributes["raw_heading"])
+
+    def test_tracker_retains_a_real_heading_when_motion_becomes_unknown(self):
+        cases = (
+            {"speed_kmh": None},
+            {"heading_deg": None},
+            {"speed_kmh": None, "heading_deg": None},
+        )
+        for missing_motion in cases:
+            with self.subTest(missing_motion=missing_motion):
+                backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+                (tracker,) = self._setup_tracker(
+                    _india_status(backend, _client_gps())
+                )
+                self.assertEqual(tracker.heading, 180)
+
+                tracker.coordinator.data["status"] = _india_status(
+                    backend, _client_gps(**missing_motion)
+                )
+
+                self.assertEqual(tracker.heading, 180)
+                self.assertEqual(tracker.extra_state_attributes["heading"], "S")
+
+
+class IndiaSpeedSensorTests(unittest.TestCase):
+    def _speed_sensor(self, gps):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        vin_info = SimpleNamespace(
+            vin="VIN1", brandName="MG", modelName="Test Vehicle"
+        )
+        coordinator = SimpleNamespace(
+            data={"status": _india_status(backend, gps)},
+            vin_info=vin_info,
+            last_update_success=True,
+        )
+        return SENSOR.SAICMGVehicleSpeedSensor(
+            coordinator,
+            SimpleNamespace(entry_id="entry-1"),
+            "Speed",
+            "speed",
+            "gpsPosition",
+            "speed",
+            "km/h",
+            "mdi:speedometer",
+            "measurement",
+            0.1,
+            "status",
+        )
+
+    def test_speed_sensor_reads_a_valid_fix(self):
+        self.assertEqual(self._speed_sensor(_client_gps()).native_value, 42.1)
+
+    def test_speed_sensor_suppresses_no_fix_coordinates(self):
+        sensor = self._speed_sensor(
+            _client_gps(gps_status=_GpsStatus.NO_SIGNAL)
+        )
+
+        self.assertIsNone(sensor.native_value)
+
+    def test_speed_sensor_reports_unknown_for_missing_speed(self):
+        sensor = self._speed_sensor(_client_gps(speed_kmh=None))
+
+        self.assertIsNone(sensor.native_value)
+
+    def test_speed_sensor_preserves_zero_speed(self):
+        self.assertEqual(
+            self._speed_sensor(_client_gps(speed_kmh=0)).native_value, 0
+        )
+
+
+class IndiaAbrpGpsTests(unittest.TestCase):
+    def setUp(self):
+        self.backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        self.abrp = ABRP.AbrpApi(None, "api-key", "user-token")
+
+    def _payload(self, gps):
+        mapped = _india_status(self.backend, gps).gpsPosition
+        return self.abrp._gps(mapped)
+
+    def test_abrp_reads_a_valid_fix(self):
+        payload = self._payload(_client_gps())
+
+        self.assertEqual(payload["lat"], 12.971599)
+        self.assertEqual(payload["lon"], 77.594566)
+        self.assertEqual(payload["speed"], 42.1)
+        self.assertEqual(payload["heading"], 180)
+
+    def test_abrp_suppresses_no_signal_and_time_fix(self):
+        for gps_status in (_GpsStatus.NO_SIGNAL, _GpsStatus.TIME_FIX):
+            with self.subTest(gps_status=gps_status):
+                self.assertEqual(
+                    self._payload(_client_gps(gps_status=gps_status)), {}
+                )
+
+    def test_abrp_omits_missing_speed_and_heading(self):
+        payload = self._payload(_client_gps(speed_kmh=None, heading_deg=None))
+
+        self.assertNotIn("speed", payload)
+        self.assertNotIn("heading", payload)
+        self.assertEqual(payload["lat"], 12.971599)
+        self.assertEqual(payload["lon"], 77.594566)
+
+    def test_abrp_preserves_zero_speed_and_heading(self):
+        payload = self._payload(_client_gps(speed_kmh=0, heading_deg=0))
+
+        self.assertEqual(payload["speed"], 0.0)
+        self.assertEqual(payload["heading"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_india_gps.py
+++ b/tests/test_india_gps.py
@@ -1,0 +1,273 @@
+"""Regression coverage for MG India GPS position.
+
+The India backend used to hand the shared entities a gpsPosition namespace
+carrying nothing but a (never-populated) speed. Reading .wayPoint off it threw
+AttributeError inside device_tracker.async_setup_entry, which swallows the
+error, so the GPS Location entity was silently never created.
+"""
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import unittest
+from enum import IntEnum
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+PACKAGE = "mg_saic_india_gps_test"
+LOADED_MODULE_NAMES = (
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.device_tracker",
+    "homeassistant.helpers",
+    "homeassistant.helpers.update_coordinator",
+    "aiohttp",
+    "mg_ismart_india_client",
+    PACKAGE,
+    f"{PACKAGE}.const",
+    f"{PACKAGE}.utils",
+    f"{PACKAGE}.api",
+    f"{PACKAGE}.backends",
+    f"{PACKAGE}.backends.india",
+    f"{PACKAGE}.device_tracker",
+)
+
+
+class _GpsStatus(IntEnum):
+    """Stand-in for mg_ismart_india_client.models.GpsStatus."""
+
+    NO_SIGNAL = 0
+    TIME_FIX = 1
+    FIX_2D = 2
+    FIX_3D = 3
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+def _module(name, **attributes):
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load(name, path, *, package=False):
+    kwargs = {"submodule_search_locations": [str(path.parent)]} if package else {}
+    spec = importlib.util.spec_from_file_location(name, path, **kwargs)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_modules():
+    previous_modules = {
+        name: sys.modules[name] for name in LOADED_MODULE_NAMES if name in sys.modules
+    }
+    try:
+        homeassistant = _module("homeassistant")
+        homeassistant.__path__ = []
+        components = _module("homeassistant.components")
+        components.__path__ = []
+        helpers = _module("homeassistant.helpers")
+        helpers.__path__ = []
+
+        class _TrackerEntity:
+            pass
+
+        _module(
+            "homeassistant.components.device_tracker", TrackerEntity=_TrackerEntity
+        )
+        _module(
+            "homeassistant.helpers.update_coordinator",
+            CoordinatorEntity=_CoordinatorEntity,
+        )
+
+        package = _module(PACKAGE)
+        package.__path__ = [str(PKG_DIR)]
+        _module(
+            f"{PACKAGE}.const",
+            DOMAIN="mg_saic",
+            LOGGER=logging.getLogger(PACKAGE),
+        )
+        _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
+
+        class _GlobalClient:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+        _module(f"{PACKAGE}.api", SAICMGAPIClient=_GlobalClient)
+
+        aiohttp = _module("aiohttp")
+        aiohttp.ClientSession = object
+
+        class _IndiaApiError(Exception):
+            pass
+
+        _module(
+            "mg_ismart_india_client",
+            MgIndiaApiError=_IndiaApiError,
+            MgIndiaClient=object,
+            hash_control_pin=lambda pin: pin,
+        )
+
+        _load(
+            f"{PACKAGE}.backends",
+            PKG_DIR / "backends" / "__init__.py",
+            package=True,
+        )
+        india = _load(
+            f"{PACKAGE}.backends.india",
+            PKG_DIR / "backends" / "india.py",
+        )
+        device_tracker = _load(
+            f"{PACKAGE}.device_tracker", PKG_DIR / "device_tracker.py"
+        )
+        return india, device_tracker
+    finally:
+        for name in LOADED_MODULE_NAMES:
+            if name in previous_modules:
+                sys.modules[name] = previous_modules[name]
+            else:
+                sys.modules.pop(name, None)
+
+
+INDIA, DEVICE_TRACKER = _load_modules()
+
+
+def _client_gps(**overrides):
+    """A GpsPosition as mg-ismart-india-client hands it over: real units."""
+    values = {
+        "latitude": 12.971599,
+        "longitude": 77.594566,
+        "altitude_m": 920,
+        "heading_deg": 180,
+        "speed_kmh": 42.1,
+        "hdop": 8,
+        "satellites": 11,
+        "gps_status": _GpsStatus.FIX_3D,
+        "position_time": 1_755_230_000,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _india_status(backend, gps):
+    return backend._map_status(
+        SimpleNamespace(
+            status_time=1_800_000_000,
+            gps=gps,
+            raw={"basicVehicleStatus": {}},
+        )
+    )
+
+
+class IndiaGpsMappingTests(unittest.TestCase):
+    def setUp(self):
+        self.backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+
+    def test_position_is_mapped_into_the_saic_shape_and_units(self):
+        gps = _india_status(self.backend, _client_gps()).gpsPosition
+
+        # Coordinates go back to micro-degrees, speed back to tenths of a km/h,
+        # which is what the shared entities divide by.
+        self.assertEqual(gps.wayPoint.position.latitude, 12_971_599)
+        self.assertEqual(gps.wayPoint.position.longitude, 77_594_566)
+        self.assertEqual(gps.wayPoint.position.altitude, 920)
+        self.assertEqual(gps.wayPoint.heading, 180)
+        self.assertEqual(gps.wayPoint.speed, 421)
+        self.assertEqual(gps.wayPoint.hdop, 8)
+        self.assertEqual(gps.wayPoint.satellites, 11)
+        self.assertEqual(gps.timeStamp, 1_755_230_000)
+
+    def test_gps_status_is_exposed_the_way_the_abrp_sender_reads_it(self):
+        # abrp._gps_has_fix accepts either the decoded member's .name or its
+        # .value, against {2, 3, "FIX_2D", "FIX_3d", "FIX_3D"}.
+        gps = _india_status(self.backend, _client_gps()).gpsPosition
+
+        self.assertEqual(gps.gpsStatus, 3)
+        self.assertEqual(gps.gps_status_decoded.name, "FIX_3D")
+        self.assertEqual(gps.gps_status_decoded.value, 3)
+
+    def test_missing_position_yields_no_waypoint_rather_than_a_broken_one(self):
+        for gps in (None, _client_gps(latitude=None, longitude=None)):
+            with self.subTest(gps=gps):
+                mapped = _india_status(self.backend, gps).gpsPosition
+                self.assertIsNone(mapped.wayPoint)
+
+    def test_absent_speed_and_heading_read_as_stationary(self):
+        # The consumers compare speed numerically without a None guard.
+        gps = _india_status(
+            self.backend, _client_gps(speed_kmh=None, heading_deg=None)
+        ).gpsPosition
+
+        self.assertEqual(gps.wayPoint.speed, 0)
+        self.assertEqual(gps.wayPoint.heading, 0)
+
+
+class IndiaDeviceTrackerTests(unittest.TestCase):
+    def _setup_tracker(self, status):
+        vin_info = SimpleNamespace(
+            vin="VIN1",
+            brandName="MG",
+            modelName="Test Vehicle",
+            modelYear="2026",
+        )
+        coordinator = SimpleNamespace(
+            data={"info": [vin_info], "status": status},
+            vin_info=vin_info,
+            last_update_success=True,
+        )
+        entry = SimpleNamespace(entry_id="entry-1")
+        hass = SimpleNamespace(data={"mg_saic": {"entry-1_coordinator": coordinator}})
+        entities = []
+
+        asyncio.run(
+            DEVICE_TRACKER.async_setup_entry(
+                hass,
+                entry,
+                lambda added, update_before_add: entities.extend(added),
+            )
+        )
+        return entities
+
+    def test_tracker_reports_the_vehicle_position(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        (tracker,) = self._setup_tracker(_india_status(backend, _client_gps()))
+
+        self.assertAlmostEqual(tracker.latitude, 12.971599)
+        self.assertAlmostEqual(tracker.longitude, 77.594566)
+        self.assertEqual(tracker.elevation, 920)
+        self.assertEqual(tracker.heading, 180)
+        self.assertEqual(tracker.source_type, "gps")
+        self.assertEqual(
+            tracker.extra_state_attributes,
+            {
+                "elevation": 920,
+                "HDOP": 8,
+                "satellites": 11,
+                "heading": "S",
+                "raw_heading": 180,
+            },
+        )
+
+    def test_tracker_survives_a_status_with_no_position(self):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        (tracker,) = self._setup_tracker(_india_status(backend, None))
+
+        self.assertIsNone(tracker.latitude)
+        self.assertIsNone(tracker.longitude)
+        self.assertIsNone(tracker.elevation)
+        self.assertEqual(tracker.extra_state_attributes, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -1,0 +1,165 @@
+# File: tests/test_vehicle_profiles.py
+#
+# Unit tests for the per-series VEHICLE_PROFILES table in const.py, focused on
+# the battery-capacity override that corrects the SAIC API's unreliable
+# totalBatteryCapacity field.
+#
+# These tests run in plain CPython (no Home Assistant installed), matching the
+# python-tests.yaml CI workflow.  const.py imports voluptuous and a Home
+# Assistant helper at module level, so those are stubbed before it is loaded,
+# and the mg_saic package is registered manually so importing const does NOT
+# execute __init__.py (which needs a full Home Assistant runtime).  This mirrors
+# tests/test_backends.py.
+#
+# Guarded invariants:
+#   * The recurring bogus SAIC placeholder totalBatteryCapacity=725 (→ 72.5 kWh)
+#     must be corrected for the IM6 (series S12L, Discussion #53): the profile
+#     forces 100 kWh for the confirmed Platinum/Performance pack.
+#   * Series matching is a substring test (VinInfo.series is e.g. 'S12L'), so
+#     the profile must resolve for the real-world series string.
+#   * The IM6 profile changes ONLY the battery capacity relative to the default
+#     profile — every other (climate/feature) field must stay identical, so the
+#     fix cannot regress the car's untested climate behaviour.
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+
+
+def _stub(name):
+    """Register a MagicMock module stub if *name* is not importable."""
+    if name in sys.modules:
+        return
+    try:
+        __import__(name)
+    except ImportError:
+        sys.modules[name] = MagicMock()
+
+
+def _load(name, path):
+    """Load a module from *path* under *name* without touching __init__.py."""
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+for _name in (
+    "voluptuous",
+    "homeassistant",
+    "homeassistant.helpers",
+    "homeassistant.helpers.config_validation",
+):
+    _stub(_name)
+
+if "mg_saic" not in sys.modules:
+    _pkg = types.ModuleType("mg_saic")
+    _pkg.__path__ = [str(PKG_DIR)]
+    sys.modules["mg_saic"] = _pkg
+
+const = _load("mg_saic.const", PKG_DIR / "const.py")
+
+
+def _resolve_profile(series):
+    """Reproduce the coordinator's substring match against VEHICLE_PROFILES.
+
+    Mirrors MGSAICDataUpdateCoordinator._process_vehicle_info: iterate the
+    profiles in order and return the first whose key is a substring of the
+    upper-cased series, else the default profile.
+    """
+    series = (series or "").upper()
+    for key, profile in const.VEHICLE_PROFILES.items():
+        if key in series:
+            return key, profile
+    return None, const.DEFAULT_VEHICLE_PROFILE
+
+
+class TestIM6BatteryCapacity(unittest.TestCase):
+    """IM6 (series S12L) — Discussion #53: correct the bogus 72.5 kWh reading."""
+
+    def test_s12l_profile_exists(self):
+        self.assertIn("S12L", const.VEHICLE_PROFILES)
+
+    def test_s12l_overrides_capacity_to_100(self):
+        # The API reports totalBatteryCapacity=725 (→ 72.5 kWh); the profile must
+        # override it with the real 100 kWh Platinum/Performance pack.
+        self.assertEqual(
+            const.VEHICLE_PROFILES["S12L"]["battery_capacity_kwh"], 100.0
+        )
+
+    def test_s12l_does_not_reuse_the_bogus_value(self):
+        # Guard against anyone "trusting the API" (None) or pinning the placeholder.
+        capacity = const.VEHICLE_PROFILES["S12L"]["battery_capacity_kwh"]
+        self.assertIsNotNone(capacity)
+        self.assertNotAlmostEqual(capacity, 72.5, places=3)
+
+    def test_real_world_series_string_resolves_to_the_profile(self):
+        # VinInfo.series in the wild is exactly 'S12L' (see #53 log).
+        key, profile = _resolve_profile("S12L")
+        self.assertEqual(key, "S12L")
+        self.assertEqual(profile["battery_capacity_kwh"], 100.0)
+
+    def test_match_is_case_insensitive_substring(self):
+        # The coordinator upper-cases the series before matching; make sure a
+        # decorated/lower-case series string still resolves.
+        key, profile = _resolve_profile("s12l l")
+        self.assertEqual(key, "S12L")
+        self.assertEqual(profile["battery_capacity_kwh"], 100.0)
+
+    def test_only_battery_capacity_differs_from_default(self):
+        # The fix must be surgical: relative to the default profile the IM6 used
+        # while unprofiled, the ONLY field that may differ is battery_capacity_kwh.
+        # Any other divergence would silently change the car's (untested) climate
+        # or feature behaviour.
+        s12l = const.VEHICLE_PROFILES["S12L"]
+        default = const.DEFAULT_VEHICLE_PROFILE
+        for field, default_value in default.items():
+            if field == "battery_capacity_kwh":
+                continue
+            self.assertIn(
+                field,
+                s12l,
+                msg=f"S12L is missing default field {field!r}",
+            )
+            self.assertEqual(
+                s12l[field],
+                default_value,
+                msg=f"S12L unexpectedly changes {field!r} vs the default profile",
+            )
+
+
+class TestBatteryCapacityOverridesAreSane(unittest.TestCase):
+    """Every declared battery override must be a plausible real capacity."""
+
+    def test_no_profile_pins_the_bogus_placeholder(self):
+        # 72.5 kWh is the ×0.1 decode of the SAIC placeholder 725 and must never
+        # be hard-coded as a "known-good" capacity.
+        for key, profile in const.VEHICLE_PROFILES.items():
+            capacity = profile.get("battery_capacity_kwh")
+            if capacity is not None:
+                self.assertNotAlmostEqual(
+                    capacity,
+                    72.5,
+                    places=3,
+                    msg=f"{key} pins the bogus 72.5 kWh placeholder",
+                )
+
+    def test_declared_capacities_are_in_a_plausible_range(self):
+        for key, profile in const.VEHICLE_PROFILES.items():
+            capacity = profile.get("battery_capacity_kwh")
+            if capacity is not None:
+                self.assertGreater(capacity, 5.0, msg=f"{key} capacity too small")
+                self.assertLess(capacity, 250.0, msg=f"{key} capacity too large")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This promotes the current beta after live Home Assistant validation.

- Adds India GPS tracking and vehicle speed with `mg-ismart-india-client 0.1.4`.
- Suppresses unusable GPS fixes and preserves unknown motion values and genuine zero speed.
- Adds the documented IM6 100 kWh battery-capacity correction.

The exact `1.2.4-beta2` release loaded cleanly on Home Assistant 2026.8.2, completed a read-only vehicle refresh, produced a valid tracker waypoint, and logged no MG SAIC errors. The full 123-test suite and the unit, hassfest, and HACS workflows passed on the stable version bump.
