### PR TITLE
fix(config-flow): clearer setup error when the account has no vehicles (#294)

### DIFF
--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -71,6 +71,16 @@ except Exception:  # noqa: BLE001 - any import failure means "no selector here"
     PASSWORD_SELECTOR = str
 
 
+class NoVehiclesFoundError(Exception):
+    """Login succeeded, but the account has no vehicles linked to it.
+
+    Raised by the vehicle-fetch helpers so the config flow can surface a
+    distinct, actionable "add a car in the iSMART app first" message instead
+    of the generic "check your credentials" error — the credentials are, in
+    fact, correct in this case (issue #294).
+    """
+
+
 @callback
 def configured_vins(hass):
     """Return a set of configured MG SAIC VINs."""
@@ -152,6 +162,11 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await self.fetch_vehicle_data(username_is_email)
                 return await self.async_step_select_vehicle()
+            except NoVehiclesFoundError as e:
+                errors["base"] = "no_vehicles"
+                LOGGER.warning(
+                    "Login succeeded but the account has no vehicles: %s", e
+                )
             except Exception as e:
                 errors["base"] = "auth"
                 LOGGER.error(f"Failed to authenticate or fetch vehicle data: {e}")
@@ -197,6 +212,11 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await self.fetch_vehicle_data(username_is_email)
                 return await self.async_step_select_vehicle()
+            except NoVehiclesFoundError as e:
+                errors["base"] = "no_vehicles"
+                LOGGER.warning(
+                    "Login succeeded but the account has no vehicles: %s", e
+                )
             except Exception as e:
                 errors["base"] = "auth"
                 LOGGER.error(f"Failed to authenticate or fetch vehicle data: {e}")
@@ -240,6 +260,12 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return await self.async_step_select_vehicle()
                 except IndiaBackendNotReadyError:
                     return self.async_abort(reason="india_backend_not_ready")
+                except NoVehiclesFoundError as e:
+                    errors["base"] = "no_vehicles"
+                    LOGGER.warning(
+                        "Login succeeded but the account has no vehicles (India): %s",
+                        e,
+                    )
                 except Exception as e:
                     errors["base"] = "auth"
                     LOGGER.error(
@@ -279,7 +305,9 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await backend.login()
             vehicles = await backend.get_vehicle_info()
             if not vehicles:
-                raise Exception("India vehicle list returned no vehicles")
+                raise NoVehiclesFoundError(
+                    "India vehicle list returned no vehicles"
+                )
             self.vehicle_options = build_vehicle_options(vehicles)
             self.vehicles = list(self.vehicle_options)
             LOGGER.info("Fetched India vehicle data successfully.")
@@ -429,6 +457,12 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await self.fetch_vehicle_data_india()
                 else:
                     await self.fetch_vehicle_data(username_is_email)
+            except NoVehiclesFoundError as e:  # noqa: BLE001 - surfaced as a form error
+                errors["base"] = "no_vehicles"
+                LOGGER.warning(
+                    "Re-authentication succeeded but the account has no vehicles: %s",
+                    e,
+                )
             except Exception as e:  # noqa: BLE001 - surfaced as a form error
                 errors["base"] = "auth"
                 LOGGER.error("Re-authentication failed: %s", e)
@@ -494,7 +528,9 @@ class SAICMGConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 not hasattr(vehicle_list_resp, "vinList")
                 or not vehicle_list_resp.vinList
             ):
-                raise Exception("Vehicle list API returned no vehicles")
+                raise NoVehiclesFoundError(
+                    "Vehicle list API returned no vehicles"
+                )
 
             # Now safely iterate over vinList
             self.vehicles = [car.vin for car in vehicle_list_resp.vinList]

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.4"
   ],
-  "version": "1.2.4"
+  "version": "1.2.5-beta1"
 }

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -73,6 +73,7 @@
     },
     "error": {
       "auth": "Failed to authenticate, please check your credentials.",
+      "no_vehicles": "Login succeeded, but no vehicles are linked to this account. Add your vehicle in the MG iSMART app first, then try again.",
       "invalid_pin": "The PIN must be exactly 4 digits."
     },
     "abort": {

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -73,6 +73,7 @@
     },
     "error": {
       "auth": "Error de autenticación, por favor verifique sus credenciales.",
+      "no_vehicles": "El inicio de sesión se realizó correctamente, pero no hay vehículos vinculados a esta cuenta. Primero añade tu vehículo en la aplicación MG iSMART y vuelve a intentarlo.",
       "invalid_pin": "El PIN debe tener exactamente 4 dígitos."
     },
     "abort": {

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -73,6 +73,7 @@
     },
     "error": {
       "auth": "Échec de l'authentification, veuillez vérifier vos identifiants.",
+      "no_vehicles": "Connexion réussie, mais aucun véhicule n'est associé à ce compte. Ajoutez d'abord votre véhicule dans l'application MG iSMART, puis réessayez.",
       "invalid_pin": "Le PIN doit comporter exactement 4 chiffres."
     },
     "abort": {

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -73,6 +73,7 @@
     },
     "error": {
       "auth": "Falha na autenticação, por favor, verifique as suas credenciais.",
+      "no_vehicles": "Início de sessão efetuado com sucesso, mas não há veículos associados a esta conta. Adicione primeiro o seu veículo na aplicação MG iSMART e tente novamente.",
       "invalid_pin": "O PIN deve ter exatamente 4 dígitos."
     },
     "abort": {

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -940,3 +940,83 @@ class TestCommandErrorHumanizer(unittest.TestCase):
         self.assertIn("could not be completed", a["reason"])
         # Raw error still available under the original key.
         self.assertEqual(a["error"], "weird backend text")
+
+
+# ── #294: "no vehicles on account" is distinct from bad credentials ───────────
+
+
+class TestNoVehiclesSetupMessage(unittest.TestCase):
+    """Issue #294: when login succeeds but the account has no vehicles, the
+    config flow must show the dedicated 'no_vehicles' error, not the generic
+    'auth' (check-your-credentials) one — the credentials are correct."""
+
+    def _login_flow(self):
+        flow = CF.SAICMGConfigFlow()
+        flow.login_type = "email"
+        flow.hass = MagicMock()
+        return flow
+
+    def _drive_login(self, side_effect):
+        flow = self._login_flow()
+
+        async def _fetch(*a, **k):
+            raise side_effect
+
+        flow.fetch_vehicle_data = _fetch
+        return _run(
+            flow.async_step_login_data(
+                {
+                    "username": "u@example.com",
+                    "password": "correct-horse",
+                    "region": "EU",
+                }
+            )
+        )
+
+    def test_no_vehicles_maps_to_no_vehicles_error(self):
+        result = self._drive_login(
+            CF.NoVehiclesFoundError("Vehicle list API returned no vehicles")
+        )
+        self.assertEqual(result["errors"]["base"], "no_vehicles")
+        self.assertEqual(result["step_id"], "login_data")
+
+    def test_other_failure_still_maps_to_auth(self):
+        # A genuine credential/connection failure must remain 'auth' so the
+        # two cases stay distinguishable.
+        result = self._drive_login(Exception("invalid credentials"))
+        self.assertEqual(result["errors"]["base"], "auth")
+
+    def test_reauth_no_vehicles_maps_to_no_vehicles_error(self):
+        flow = CF.SAICMGConfigFlow()
+        flow.login_type = "email"
+        flow.region = "EU"
+        flow.username = "driver@example.com"
+        flow.hass = MagicMock()
+        flow._existing_entry = _FakeEntry(
+            {"login_type": "email", "username": "driver@example.com", "region": "EU"}
+        )
+
+        async def _fetch(*a, **k):
+            raise CF.NoVehiclesFoundError("Vehicle list API returned no vehicles")
+
+        flow.fetch_vehicle_data = _fetch
+        result = _run(flow.async_step_reauth_confirm({"password": "correct-horse"}))
+        self.assertEqual(result["errors"]["base"], "no_vehicles")
+
+    def test_no_vehicles_error_string_is_translated(self):
+        # The error key the flow sets must exist in every shipped language file,
+        # otherwise Home Assistant shows the raw key to the user.
+        import json
+
+        base = Path(CF.__file__).resolve().parent / "translations"
+        for lang in ("en", "es", "fr", "pt"):
+            data = json.load(open(base / f"{lang}.json", encoding="utf-8"))
+            self.assertIn(
+                "no_vehicles",
+                data["config"]["error"],
+                msg=f"{lang}.json is missing config.error.no_vehicles",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #294. When a user's credentials are correct but their MG account has **no vehicles linked yet**, setup failed with the generic *"Failed to authenticate, please check your credentials."* — which points people at the wrong problem. This surfaces a distinct, actionable message instead.

## Root cause
Both vehicle-fetch helpers raised a bare `Exception("...returned no vehicles")`, and every login `except` block collapses any exception to `errors["base"] = "auth"`. The "empty account" case was therefore indistinguishable from bad credentials.

## Changes
- New `NoVehiclesFoundError`, raised by `fetch_vehicle_data` (global) and `fetch_vehicle_data_india` when the vehicle list is empty.
- Mapped to a new `no_vehicles` form error at **all four** login entry points: email/phone (`async_step_login_data`), custom region, India PIN, and reauth (`async_step_reauth_confirm`).
- New `no_vehicles` translation string in `en`, `es`, `fr`, `pt`. English:
  > Login succeeded, but no vehicles are linked to this account. Add your vehicle in the MG iSMART app first, then try again.
- Genuine auth/connection failures are untouched — they still map to `auth`.

## India note (no change required from @john-lazarus)
The India path is already covered: `IndiaBackend.get_vehicle_info()` returns `[]` for a car-less account (the client's `vehicles()` returns an empty list rather than raising), so the same `if not vehicles: raise NoVehiclesFoundError` fires and the India PIN step maps it to `no_vehicles`.

This relies on the informal contract that the India client's `vehicles()` keeps **returning `[]`** (not raising) on an empty account. If a future client refactor made it raise a `MgIndiaApiError` for "no vehicles" instead, India users would fall back to the generic `auth` message and we'd want to catch that specific error here too.

## Tests
`tests/test_setup_and_config_flow.py`: no-vehicles → `no_vehicles`; other failures still → `auth`; the reauth path; and every shipped locale carries the key.

## Notes
- No README change — the in-flow message is self-explanatory.
- Manifest bumped to `1.2.5-beta1`.
