### PR TITLE
feat(India): expose Series and Colour sensors, fix Model sensor

### DIFF
--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -141,7 +141,7 @@ def _looks_electric(vehicle) -> bool:
         str(value or "")
         for value in (
             getattr(vehicle, "name", None),
-            getattr(vehicle, "model_name", None),
+            getattr(vehicle, "model", None),
             getattr(vehicle, "brand", None),
             _vehicle_config(vehicle, "EV"),
             _vehicle_config(vehicle, "BType"),
@@ -211,7 +211,7 @@ class IndiaBackend:
 
     def _map_vehicle(self, vehicle):
         model_name = (
-            getattr(vehicle, "model_name", None)
+            getattr(vehicle, "model", None)
             or getattr(vehicle, "name", None)
             or "MG India"
         )
@@ -236,7 +236,8 @@ class IndiaBackend:
             brandName=brand,
             modelName=model_name,
             modelYear=getattr(vehicle, "model_year", None) or "",
-            series=getattr(vehicle, "name", None) or model_name,
+            series=getattr(vehicle, "series", None) or model_name,
+            colorName=getattr(vehicle, "color_name", None),
             vehicleModelConfiguration=configs,
             raw=getattr(vehicle, "raw", None),
         )

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -236,7 +236,7 @@ class IndiaBackend:
             brandName=brand,
             modelName=model_name,
             modelYear=getattr(vehicle, "model_year", None) or "",
-            series=getattr(vehicle, "series", None) or model_name,
+            series=getattr(vehicle, "series", None) or "",
             colorName=getattr(vehicle, "color_name", None),
             vehicleModelConfiguration=configs,
             raw=getattr(vehicle, "raw", None),

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.4"
+    "mg-ismart-india-client==0.1.5"
   ],
   "version": "1.2.5-beta1"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfSpeed,
 )
-from .backends import Feature
+from .backends import Feature, REGION_INDIA
 from datetime import datetime, timezone
 
 from .const import (
@@ -176,22 +176,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
             SAICMGVehicleDetailSensor(
                 coordinator,
                 entry,
-                "Series",
-                "series",
-                "info",
-            ),
-            SAICMGVehicleDetailSensor(
-                coordinator,
-                entry,
                 "Model Year",
                 "modelYear",
-                "info",
-            ),
-            SAICMGVehicleDetailSensor(
-                coordinator,
-                entry,
-                "Colour",
-                "colorName",
                 "info",
             ),
             SAICMGVINSensor(
@@ -277,6 +263,28 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 "status",
             ),
         ]
+
+        if getattr(entry, "data", {}).get("region") == REGION_INDIA:
+            if getattr(vin_info, "series", None):
+                sensors.append(
+                    SAICMGVehicleDetailSensor(
+                        coordinator,
+                        entry,
+                        "Series",
+                        "series",
+                        "info",
+                    )
+                )
+            if getattr(vin_info, "colorName", None):
+                sensors.append(
+                    SAICMGVehicleDetailSensor(
+                        coordinator,
+                        entry,
+                        "Colour",
+                        "colorName",
+                        "info",
+                    )
+                )
 
         if vehicle_type in ["PHEV", "HEV", "ICE"]:
             # PHEV, HEV, ICE Sensors

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -176,8 +176,22 @@ async def async_setup_entry(hass, entry, async_add_entities):
             SAICMGVehicleDetailSensor(
                 coordinator,
                 entry,
+                "Series",
+                "series",
+                "info",
+            ),
+            SAICMGVehicleDetailSensor(
+                coordinator,
+                entry,
                 "Model Year",
                 "modelYear",
+                "info",
+            ),
+            SAICMGVehicleDetailSensor(
+                coordinator,
+                entry,
+                "Colour",
+                "colorName",
                 "info",
             ),
             SAICMGVINSensor(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -269,6 +269,37 @@ class TestIndiaBackendAdapter(unittest.TestCase):
         self.assertEqual(configs["EV"], "1")
         self.assertEqual(configs["BType"], "1")
 
+    def test_vehicle_metadata_preserves_model_series_and_colour(self):
+        vehicle = self.backend._map_vehicle(
+            types.SimpleNamespace(
+                vin="VIN1",
+                name="Vehicle nickname",
+                brand="MG",
+                model="Windsor EV",
+                series="EQ100",
+                color_name="Clay Beige",
+                model_year="2026",
+                raw={},
+            )
+        )
+
+        self.assertEqual(vehicle.modelName, "Windsor EV")
+        self.assertEqual(vehicle.series, "EQ100")
+        self.assertEqual(vehicle.colorName, "Clay Beige")
+
+        without_series = self.backend._map_vehicle(
+            types.SimpleNamespace(
+                vin="VIN2",
+                name="Vehicle nickname",
+                brand="MG",
+                model="Windsor EV",
+                model_year="2026",
+                raw={},
+            )
+        )
+        self.assertEqual(without_series.series, "")
+        self.assertEqual(without_series.series.upper(), "")
+
     def test_status_is_saic_shaped_and_validator_safe(self):
         status = _run(self.backend.get_vehicle_status("VIN1"))
         self.assertGreater(status.statusTime, 1_700_000_000)

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -163,12 +163,24 @@ BACKENDS, INDIA, SENSOR = _load_modules()
 
 
 class IndiaBEVStateOfChargeTests(unittest.TestCase):
-    def _setup_entities(self, backend, vehicle_type, status, charging=None):
+    def _setup_entities(
+        self,
+        backend,
+        vehicle_type,
+        status,
+        charging=None,
+        *,
+        region=None,
+        series=None,
+        colour=None,
+    ):
         vin_info = SimpleNamespace(
             vin="VIN1",
             brandName="MG",
             modelName="Test Vehicle",
             modelYear="2026",
+            series=series,
+            colorName=colour,
         )
         coordinator = SimpleNamespace(
             data={"info": [vin_info], "status": status, "charging": charging},
@@ -185,7 +197,7 @@ class IndiaBEVStateOfChargeTests(unittest.TestCase):
         coordinator.backend_supports = lambda feature: BACKENDS.backend_supports(
             backend, feature
         )
-        entry = SimpleNamespace(entry_id="entry-1")
+        entry = SimpleNamespace(entry_id="entry-1", data={"region": region})
         hass = SimpleNamespace(
             data={"mg_saic": {"entry-1_coordinator": coordinator}}
         )
@@ -199,6 +211,34 @@ class IndiaBEVStateOfChargeTests(unittest.TestCase):
             )
         )
         return entities
+
+    def test_vehicle_metadata_entities_require_india_region_and_values(self):
+        india_backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        global_backend = SimpleNamespace(supported_features=BACKENDS.GLOBAL_FEATURES)
+        cases = (
+            (india_backend, "India", "EQ100", "Clay Beige", {"series", "colorName"}),
+            (global_backend, "EU", "EQ100", "Clay Beige", set()),
+            (india_backend, "India", "EQ100", "", {"series"}),
+            (india_backend, "India", None, None, set()),
+        )
+
+        for backend, region, series, colour, expected in cases:
+            with self.subTest(region=region, series=series, colour=colour):
+                entities = self._setup_entities(
+                    backend,
+                    "UNKNOWN",
+                    None,
+                    region=region,
+                    series=series,
+                    colour=colour,
+                )
+                fields = {
+                    entity._field
+                    for entity in entities
+                    if isinstance(entity, SENSOR.SAICMGVehicleDetailSensor)
+                    and entity._field in {"series", "colorName"}
+                }
+                self.assertEqual(fields, expected)
 
     @staticmethod
     def _india_status(backend, percentage):


### PR DESCRIPTION
## Summary
- India backend: fix Model sensor showing raw series code (e.g. "EQ100") instead of the human-readable name (e.g. "Windsor") — `_map_vehicle` was reading a nonexistent `model_name` attribute and silently falling back to `vehicle.name`, which prefers the raw series code.
- India backend: `series` now reads the actual `vehicle.series` attribute instead of being aliased to `vehicle.name` (same root cause).
- India backend: pass through new `colorName` field.
- Add two new sensors: "Series" and "Colour", using the existing generic `SAICMGVehicleDetailSensor`.

Requires the library-side PR for `color_name`/`series` to actually populate on India accounts but safe to merge independently since both fields default to `None` and the sensors already handle missing values:
 - https://github.com/john-lazarus/mg-ismart-india-client/pull/5
