### PR TITLE
feat(india): expose EV charging status sensors

### DIFF
--- a/custom_components/mg_saic/backends/__init__.py
+++ b/custom_components/mg_saic/backends/__init__.py
@@ -55,6 +55,7 @@ class Feature(str, Enum):
     # Data retrieval
     STATUS = "status"                            # get_vehicle_status
     STATE_OF_CHARGE = "state_of_charge"          # SOC from status or charging data
+    STATE_OF_CHARGE_NON_BEV = "state_of_charge_non_bev"  # PHEV/HEV SOC: basicVehicleStatus.extendedData1 is battery SOC, not fuel
     CHARGING_DATA = "charging_data"              # get_charging_info (incl. SOC)
     ALARM_MESSAGES = "alarm_messages"            # get_alarm_messages / set_alarm_switches / message poller
 
@@ -87,10 +88,14 @@ GLOBAL_FEATURES: frozenset[Feature] = frozenset(Feature)
 
 # Features implemented AND confirmed on a real vehicle by the India TAP
 # client (John Lazarus, mg-ismart-india-ha). MG India reports BEV state of
-# charge in the ordinary vehicle-status payload, but separate charging data
-# and charging controls are deliberately absent.
+# charge in the ordinary vehicle-status payload, and charging telemetry in a
+# separate frame; charging controls are deliberately absent.
 # ALARM_MESSAGES is absent because the TAP protocol has no message-list
 # endpoint — the account message poller must not run for India accounts.
+# STATE_OF_CHARGE_NON_BEV is absent because India repurposes
+# basicVehicleStatus.extendedData1 to carry fuel level: on a BEV that field is
+# the SOC, but on a PHEV/HEV it is litres of petrol, so a non-BEV must not read
+# SOC from it even though CHARGING_DATA is now supported.
 INDIA_FEATURES: frozenset[Feature] = frozenset(
     {
         Feature.STATUS,

--- a/custom_components/mg_saic/backends/__init__.py
+++ b/custom_components/mg_saic/backends/__init__.py
@@ -95,6 +95,9 @@ INDIA_FEATURES: frozenset[Feature] = frozenset(
     {
         Feature.STATUS,
         Feature.STATE_OF_CHARGE,
+        # Charging telemetry decoded from the 63-byte TAP frame: voltage,
+        # current, power and charge state (get_charging_info in india.py).
+        Feature.CHARGING_DATA,
         Feature.LOCK,
         Feature.TAILGATE,
         Feature.WINDOWS,

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -72,6 +72,34 @@ def _tyre_pressure(status, attribute: str) -> float | None:
     return round(psi * _BAR_PER_PSI / _EU_TYRE_BAR_PER_UNIT, 2)
 
 
+# The global SAIC protocol encodes charging current as an offset from a 1000 A
+# zero point (decoded as 1000 - raw * CHARGING_CURRENT_FACTOR), so real amps are
+# re-encoded against the same zero point below.
+_CHARGING_CURRENT_ZERO_A = 1000
+
+# bmsChrgSts codes the shared charging sensors decode; names match the mapping in
+# sensor.py. India reports charging as two booleans, so only these three are used.
+_BMS_CHRG_STS_UNPLUGGED = 0
+_BMS_CHRG_STS_CHARGING = 3
+_BMS_CHRG_STS_PLUGGED_IN = 7  # connected but not charging: paused or full
+
+# The Charging Duration sensor reads rvsChargeStatus.chargingDuration with
+# DATA_100_DECIMAL_CORRECTION and labels the result minutes, i.e. it expects
+# hundredths of a minute. The India client reports elapsed session time in
+# seconds, so convert instead of passing the seconds straight through.
+_SECONDS_PER_MINUTE = 60
+_CHARGING_DURATION_UNITS_PER_MINUTE = 100
+
+
+def _charging_duration_units(seconds: int | None) -> int | None:
+    """Convert elapsed seconds into the hundredths-of-a-minute the sensor decodes."""
+    if seconds is None:
+        return None
+    return round(
+        seconds / _SECONDS_PER_MINUTE * _CHARGING_DURATION_UNITS_PER_MINUTE
+    )
+
+
 def _vehicle_config(vehicle, code: str, default=None):
     raw = getattr(vehicle, "raw", None)
     if isinstance(raw, dict):
@@ -310,43 +338,55 @@ class IndiaBackend:
         await (await self._ensure_client()).control_climate(False)
 
     async def get_charging_info(self, vin):
-        """Map the India EV charging frame onto the chrgMgmtData shape the
-        charging sensors read.
+        """Map the India EV charging status onto the chrgMgmtData / rvsChargeStatus
+        shapes the shared charging sensors read.
 
-        The India frame reports charging voltage (volts) and current (amps) in
-        real units. The shared charging/power sensors expect raw fields on the
-        global SAIC scales (voltage = raw * CHARGING_VOLTAGE_FACTOR, current =
-        1000 - raw * CHARGING_CURRENT_FACTOR), so we invert those scales here;
-        the sensors then decode straight back to the real volts/amps and derive
-        power from them. Returns None when no charging frame is seen, which the
-        coordinator handles gracefully.
+        Voltage, current, SOC and range come from the client's declared-unit
+        ChargeStatus fields (volts, amps, percent, km) and are re-encoded onto the
+        global SAIC raw scales the shared sensors decode
+        (CHARGING_VOLTAGE_FACTOR / CHARGING_CURRENT_FACTOR / tenths), rather than
+        assuming the India protocol's raw field values happen to share the global
+        protocol's raw scale. rvsChargeStatus is likewise built field by field,
+        so every value the sensors read has a named source and a stated scale
+        assumption. Returns None when the vehicle sends
+        no charging frame, which the coordinator handles gracefully; session and
+        protocol failures propagate from the client so they are logged rather than
+        silently reported as "not charging".
         """
         self._set_vin(vin)
         charge = await (await self._ensure_client()).charge_status()
-        if not charge:
+        if charge is None:
             return None
-        voltage = charge.get("charging_voltage")
-        current = charge.get("charging_current")
-        if charge.get("is_charging"):
-            bms_chrg_sts = 3  # Charging
-        elif charge.get("charge_complete"):
-            bms_chrg_sts = 2  # Charging Finished (plugged in, battery full)
+        if charge.is_charging:
+            bms_chrg_sts = _BMS_CHRG_STS_CHARGING
+        elif charge.is_plugged_in:
+            bms_chrg_sts = _BMS_CHRG_STS_PLUGGED_IN
         else:
-            bms_chrg_sts = 0  # Unplugged
+            bms_chrg_sts = _BMS_CHRG_STS_UNPLUGGED
         chrg_mgmt = _ns(
-            bmsPackVol=(
-                round(voltage / CHARGING_VOLTAGE_FACTOR)
-                if voltage is not None
-                else None
+            bmsPackVol=round(charge.charging_voltage / CHARGING_VOLTAGE_FACTOR),
+            bmsPackCrnt=round(
+                (_CHARGING_CURRENT_ZERO_A - charge.charging_current)
+                / CHARGING_CURRENT_FACTOR
             ),
-            bmsPackCrnt=(
-                round((1000 - current) / CHARGING_CURRENT_FACTOR)
-                if current is not None
-                else None
-            ),
+            bmsPackSOCDsp=_tenths(charge.soc),
             bmsChrgSts=bms_chrg_sts,
         )
-        return _ns(chrgMgmtData=chrg_mgmt, rvsChargeStatus=_ns())
+        rvs = _ns(
+            # Range and odometer come back in real units and re-encode to tenths.
+            fuelRangeElec=_tenths(charge.range_km),
+            mileage=_tenths(charge.odometer_km),
+            chargingGunState=charge.is_plugged_in,
+            chargingDuration=_charging_duration_units(charge.charge_time_elapsed_s),
+            # These three have no confirmed scale on the India frame, so the
+            # client hands back the vehicle's own integer and we forward it on
+            # the assumption that it matches the global protocol's scale. If a
+            # sensor reads wrong, this is the line to correct.
+            totalBatteryCapacity=charge.total_battery_capacity_raw,
+            mileageSinceLastCharge=charge.mileage_since_last_charge_raw,
+            powerUsageSinceLastCharge=charge.power_usage_since_last_charge_raw,
+        )
+        return _ns(chrgMgmtData=chrg_mgmt, rvsChargeStatus=rvs)
 
     async def control_heated_seat(self, vin, seat, level):
         self._set_vin(vin)

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -9,7 +9,12 @@ import time
 from types import SimpleNamespace
 
 from aiohttp import ClientSession
-from mg_ismart_india_client import MgIndiaApiError, MgIndiaClient, hash_control_pin
+from mg_ismart_india_client import (
+    ChargingStatusUnavailable,
+    MgIndiaApiError,
+    MgIndiaClient,
+    hash_control_pin,
+)
 
 from ..const import CHARGING_CURRENT_FACTOR, CHARGING_VOLTAGE_FACTOR, LOGGER
 from . import INDIA_FEATURES
@@ -92,7 +97,11 @@ _CHARGING_DURATION_UNITS_PER_MINUTE = 100
 
 
 def _charging_duration_units(seconds: int | None) -> int | None:
-    """Convert elapsed seconds into the hundredths-of-a-minute the sensor decodes."""
+    """Convert elapsed seconds into the hundredths-of-a-minute the sensor decodes.
+
+    :param seconds: :attr:`~mg_ismart_india_client.models.ChargeStatus.charge_time_elapsed_s`.
+    :returns: the value for ``rvsChargeStatus.chargingDuration``, or ``None``.
+    """
     if seconds is None:
         return None
     return round(
@@ -390,34 +399,38 @@ class IndiaBackend:
         await (await self._ensure_client()).control_climate(False)
 
     async def get_charging_info(self, vin):
-        """Map the India EV charging status onto the chrgMgmtData / rvsChargeStatus
-        shapes the shared charging sensors read.
+        """Map the India EV charging status onto the ``chrgMgmtData`` /
+        ``rvsChargeStatus`` shapes the shared charging sensors read.
 
-        Voltage, current, SOC and range come from the client's declared-unit
-        ChargeStatus fields (volts, amps, percent, km) and are re-encoded onto the
-        global SAIC raw scales the shared sensors decode
-        (CHARGING_VOLTAGE_FACTOR / CHARGING_CURRENT_FACTOR / tenths), rather than
-        assuming the India protocol's raw field values happen to share the global
-        protocol's raw scale. rvsChargeStatus is likewise built field by field,
-        so every value the sensors read has a named source and a stated scale
-        assumption. Returns None when the poll budget expires without a charging
-        frame, which the coordinator handles gracefully; session and protocol
-        failures propagate from the client so they are logged rather than
-        silently reported as "not charging".
+        Voltage, current, SOC and range come from the declared-unit fields of
+        :class:`~mg_ismart_india_client.models.ChargeStatus` (volts, amps,
+        percent, km) and are re-encoded onto the global SAIC raw scales the
+        shared sensors decode (:data:`~..const.CHARGING_VOLTAGE_FACTOR` /
+        :data:`~..const.CHARGING_CURRENT_FACTOR` / tenths), rather than assuming
+        the India protocol's raw field values happen to share the global
+        protocol's raw scale. ``rvsChargeStatus`` is likewise built field by
+        field, so every value the sensors read has a named source and a stated
+        scale assumption.
 
-        The client raises MgIndiaApiError for the exhausted-budget case (an idle
-        vehicle sends a charging frame of its own, so a missing frame means the
-        data was unavailable, not that the car is idle). That is a routine poll
-        outcome here rather than a fault, so it is translated to None; every
-        other MgIndiaApiError still propagates.
+        :param vin: VIN to report charging status for.
+        :returns: a namespace carrying ``chrgMgmtData`` and ``rvsChargeStatus``,
+            or ``None`` when the poll budget expires without a charging frame
+            (the coordinator handles that gracefully).
+        :raises MgIndiaApiError: on session and protocol failures, so they are
+            logged rather than silently reported as "not charging".
+
+        :meth:`~mg_ismart_india_client.client.MgIndiaClient.charge_status` raises
+        :exc:`~mg_ismart_india_client.client.ChargingStatusUnavailable` for the
+        exhausted-budget case (an idle vehicle sends a charging frame of its own,
+        so a missing frame means the data was unavailable, not that the car is
+        idle). That is a routine poll outcome here rather than a fault, so it is
+        translated to ``None``; every other
+        :exc:`~mg_ismart_india_client.crypto.MgIndiaApiError` still propagates.
         """
         self._set_vin(vin)
         try:
             charge = await (await self._ensure_client()).charge_status()
-        except MgIndiaApiError as err:
-            # Message coupled to MgIndiaClient.charge_status's unavailable path.
-            if "not available after polling" not in str(err):
-                raise
+        except ChargingStatusUnavailable:
             LOGGER.debug(
                 "No charging frame for VIN %s after polling; reporting no charging data",
                 vin,

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -400,14 +400,28 @@ class IndiaBackend:
         assuming the India protocol's raw field values happen to share the global
         protocol's raw scale. rvsChargeStatus is likewise built field by field,
         so every value the sensors read has a named source and a stated scale
-        assumption. Returns None when the vehicle sends
-        no charging frame, which the coordinator handles gracefully; session and
-        protocol failures propagate from the client so they are logged rather than
+        assumption. Returns None when the poll budget expires without a charging
+        frame, which the coordinator handles gracefully; session and protocol
+        failures propagate from the client so they are logged rather than
         silently reported as "not charging".
+
+        The client raises MgIndiaApiError for the exhausted-budget case (an idle
+        vehicle sends a charging frame of its own, so a missing frame means the
+        data was unavailable, not that the car is idle). That is a routine poll
+        outcome here rather than a fault, so it is translated to None; every
+        other MgIndiaApiError still propagates.
         """
         self._set_vin(vin)
-        charge = await (await self._ensure_client()).charge_status()
-        if charge is None:
+        try:
+            charge = await (await self._ensure_client()).charge_status()
+        except MgIndiaApiError as err:
+            # Message coupled to MgIndiaClient.charge_status's unavailable path.
+            if "not available after polling" not in str(err):
+                raise
+            LOGGER.debug(
+                "No charging frame for VIN %s after polling; reporting no charging data",
+                vin,
+            )
             return None
         if charge.is_charging:
             bms_chrg_sts = _BMS_CHRG_STS_CHARGING

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -9,12 +9,7 @@ import time
 from types import SimpleNamespace
 
 from aiohttp import ClientSession
-from mg_ismart_india_client import (
-    ChargingStatusUnavailable,
-    MgIndiaApiError,
-    MgIndiaClient,
-    hash_control_pin,
-)
+from mg_ismart_india_client import MgIndiaApiError, MgIndiaClient, hash_control_pin
 
 from ..const import CHARGING_CURRENT_FACTOR, CHARGING_VOLTAGE_FACTOR, LOGGER
 from . import INDIA_FEATURES
@@ -205,6 +200,8 @@ class IndiaBackend:
         self.region_name = "India"
         self._session: ClientSession | None = None
         self._client: MgIndiaClient | None = None
+        self._charge_status_by_vin = {}
+        self._electric_vins = set()
         self._seat_levels = {"front_left": 0, "front_right": 0}
 
     async def _ensure_client(self) -> MgIndiaClient:
@@ -238,13 +235,21 @@ class IndiaBackend:
     async def get_vehicle_info(self):
         client = await self._ensure_client()
         vehicles = await client.vehicles()
+        self._electric_vins = {
+            vehicle.vin for vehicle in vehicles if _looks_electric(vehicle)
+        }
         if self.vin is None and vehicles:
             self._set_vin(vehicles[0].vin)
         return [self._map_vehicle(vehicle) for vehicle in vehicles]
 
     async def get_vehicle_status(self, vin: str | None = None):
         self._set_vin(vin)
-        return self._map_status(await (await self._ensure_client()).status())
+        self._charge_status_by_vin.pop(self.vin, None)
+        status = await (await self._ensure_client()).status(
+            include_charge=self.vin in self._electric_vins
+        )
+        self._charge_status_by_vin[self.vin] = status.charge
+        return self._map_status(status)
 
     def _map_vehicle(self, vehicle):
         model_name = (
@@ -412,29 +417,17 @@ class IndiaBackend:
         field, so every value the sensors read has a named source and a stated
         scale assumption.
 
+        The preceding status refresh requests both frames from the shared TAP
+        stream and stores the charging frame here. This method only maps that
+        result; it must not start a second poll.
+
         :param vin: VIN to report charging status for.
         :returns: a namespace carrying ``chrgMgmtData`` and ``rvsChargeStatus``,
-            or ``None`` when the poll budget expires without a charging frame
-            (the coordinator handles that gracefully).
-        :raises MgIndiaApiError: on session and protocol failures, so they are
-            logged rather than silently reported as "not charging".
-
-        :meth:`~mg_ismart_india_client.client.MgIndiaClient.charge_status` raises
-        :exc:`~mg_ismart_india_client.client.ChargingStatusUnavailable` for the
-        exhausted-budget case (an idle vehicle sends a charging frame of its own,
-        so a missing frame means the data was unavailable, not that the car is
-        idle). That is a routine poll outcome here rather than a fault, so it is
-        translated to ``None``; every other
-        :exc:`~mg_ismart_india_client.crypto.MgIndiaApiError` still propagates.
+            or ``None`` when the status poll did not receive a charging frame.
         """
         self._set_vin(vin)
-        try:
-            charge = await (await self._ensure_client()).charge_status()
-        except ChargingStatusUnavailable:
-            LOGGER.debug(
-                "No charging frame for VIN %s after polling; reporting no charging data",
-                vin,
-            )
+        charge = self._charge_status_by_vin.pop(self.vin, None)
+        if charge is None:
             return None
         if charge.is_charging:
             bms_chrg_sts = _BMS_CHRG_STS_CHARGING
@@ -459,11 +452,6 @@ class IndiaBackend:
             chargingDuration=_charging_duration_units(charge.charge_time_elapsed_s),
             totalBatteryCapacity=_tenths(charge.total_battery_capacity_kwh),
             mileageSinceLastCharge=_tenths(charge.distance_since_last_charge_km),
-            # Energy-since-charge has no confirmed India scale yet, so the client
-            # hands back the vehicle's own integer and we forward it on the
-            # assumption it matches the global scale. If the sensor reads wrong,
-            # this is the line to correct.
-            powerUsageSinceLastCharge=charge.power_usage_since_last_charge_raw,
         )
         return _ns(chrgMgmtData=chrg_mgmt, rvsChargeStatus=rvs)
 

--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from aiohttp import ClientSession
 from mg_ismart_india_client import MgIndiaApiError, MgIndiaClient, hash_control_pin
 
-from ..const import LOGGER
+from ..const import CHARGING_CURRENT_FACTOR, CHARGING_VOLTAGE_FACTOR, LOGGER
 from . import INDIA_FEATURES
 
 
@@ -308,6 +308,45 @@ class IndiaBackend:
     async def stop_ac(self, vin):
         self._set_vin(vin)
         await (await self._ensure_client()).control_climate(False)
+
+    async def get_charging_info(self, vin):
+        """Map the India EV charging frame onto the chrgMgmtData shape the
+        charging sensors read.
+
+        The India frame reports charging voltage (volts) and current (amps) in
+        real units. The shared charging/power sensors expect raw fields on the
+        global SAIC scales (voltage = raw * CHARGING_VOLTAGE_FACTOR, current =
+        1000 - raw * CHARGING_CURRENT_FACTOR), so we invert those scales here;
+        the sensors then decode straight back to the real volts/amps and derive
+        power from them. Returns None when no charging frame is seen, which the
+        coordinator handles gracefully.
+        """
+        self._set_vin(vin)
+        charge = await (await self._ensure_client()).charge_status()
+        if not charge:
+            return None
+        voltage = charge.get("charging_voltage")
+        current = charge.get("charging_current")
+        if charge.get("is_charging"):
+            bms_chrg_sts = 3  # Charging
+        elif charge.get("charge_complete"):
+            bms_chrg_sts = 2  # Charging Finished (plugged in, battery full)
+        else:
+            bms_chrg_sts = 0  # Unplugged
+        chrg_mgmt = _ns(
+            bmsPackVol=(
+                round(voltage / CHARGING_VOLTAGE_FACTOR)
+                if voltage is not None
+                else None
+            ),
+            bmsPackCrnt=(
+                round((1000 - current) / CHARGING_CURRENT_FACTOR)
+                if current is not None
+                else None
+            ),
+            bmsChrgSts=bms_chrg_sts,
+        )
+        return _ns(chrgMgmtData=chrg_mgmt, rvsChargeStatus=_ns())
 
     async def control_heated_seat(self, vin, seat, level):
         self._set_vin(vin)

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.5"
+    "mg-ismart-india-client==0.1.7"
   ],
   "version": "1.2.7-beta5"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -347,17 +347,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
             # meaningful charging-endpoint data, but basicVehicleStatus.
             # extendedData1 was confirmed to independently track its HV
             # battery SoC (values fell from 78 -> 73 across polls while
-            # driving). Gating HEV on CHARGING_DATA support (same as PHEV)
-            # rather than adding it unconditionally keeps this off the
-            # India backend, where extendedData1 is repurposed to carry
-            # fuel_level rather than battery SoC and INDIA_FEATURES does
-            # not advertise CHARGING_DATA.
+            # driving). Gating HEV and PHEV on STATE_OF_CHARGE_NON_BEV rather
+            # than adding it unconditionally keeps this off the India backend,
+            # where extendedData1 is repurposed to carry fuel_level rather than
+            # battery SoC. India advertises CHARGING_DATA (its charging frame
+            # carries a real bmsPackSOCDsp), but the SOC sensor falls back to
+            # extendedData1 whenever that frame is missing, so the gate has to
+            # be the narrower feature and not CHARGING_DATA.
             if (
                 vehicle_type in ["BEV", "PHEV", "HEV"]
                 and coordinator.backend_supports(Feature.STATE_OF_CHARGE)
                 and (
                     vehicle_type == "BEV"
-                    or coordinator.backend_supports(Feature.CHARGING_DATA)
+                    or coordinator.backend_supports(Feature.STATE_OF_CHARGE_NON_BEV)
                 )
             ):
                 sensors.append(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -16,9 +16,9 @@
 #     user's commands.
 #   * Backend selection: region "India" -> IndiaBackend, everything else ->
 #     the untouched global SAICMGAPIClient.
-#   * Capability sets: charging/alarm families must stay OUT of
-#     INDIA_FEATURES until confirmed on a real car; status-reported SOC and
-#     other confirmed features must stay IN.
+#   * Capability sets: charging-control and alarm families must stay OUT of
+#     INDIA_FEATURES until confirmed on a real car; status-reported SOC,
+#     charging telemetry and other confirmed features must stay IN.
 #   * Legacy fallback: clients that declare no feature set are treated as
 #     fully featured (pre-split global behaviour).
 
@@ -199,11 +199,17 @@ class TestCapabilitySets(unittest.TestCase):
         Feature.CLIMATE,
         Feature.HEATED_SEATS,
         Feature.FIND_MY_CAR,
+        # Charging telemetry: decoded from the app-id 511 TAP frame and
+        # confirmed against captures spanning ~4-18 A and 45-100% SOC.
+        Feature.CHARGING_DATA,
     }
 
     # Must remain absent until decoded AND confirmed on a real India car.
     INDIA_FORBIDDEN = {
-        Feature.CHARGING_DATA,
+        # Not "unconfirmed" but structurally impossible: India reports fuel
+        # level in the field a non-BEV would read SOC from, so PHEV/HEV SOC
+        # cannot come from status there.
+        Feature.STATE_OF_CHARGE_NON_BEV,
         Feature.CHARGING_CONTROL,
         Feature.CHARGING_PORT_LOCK,
         Feature.SCHEDULED_CHARGING,

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -253,6 +253,7 @@ class TestIndiaBackendAdapter(unittest.TestCase):
         self.backend = india.IndiaBackend(
             username="9999999999", password="p", vin="VIN1", pin_hash="ABC"
         )
+        self.backend._electric_vins.add("VIN1")
         self.fake = FakeIndiaClient()
         self.backend._client = self.fake
 
@@ -308,6 +309,7 @@ class TestIndiaBackendAdapter(unittest.TestCase):
 
     def test_status_is_saic_shaped_and_validator_safe(self):
         status = _run(self.backend.get_vehicle_status("VIN1"))
+        self.assertTrue(self.fake.status_include_charge)
         self.assertGreater(status.statusTime, 1_700_000_000)
         self.assertEqual(status.basicVehicleStatus.lockStatus, 1)
         self.assertEqual(status.basicVehicleStatus.driverDoor, 0)
@@ -320,6 +322,31 @@ class TestIndiaBackendAdapter(unittest.TestCase):
             and status.basicVehicleStatus.fuelRangeElec == 0
             and status.basicVehicleStatus.mileage == 0
         )
+
+    def test_charging_info_reuses_charge_from_status_poll(self):
+        _run(self.backend.get_vehicle_status("VIN1"))
+        charging = _run(self.backend.get_charging_info("VIN1"))
+
+        self.assertEqual(charging.chrgMgmtData.bmsPackVol, 1440)
+        self.assertEqual(charging.chrgMgmtData.bmsPackCrnt, 19680)
+        self.assertEqual(charging.chrgMgmtData.bmsPackSOCDsp, 625)
+        self.assertEqual(charging.chrgMgmtData.bmsChrgSts, 3)
+        self.assertEqual(charging.rvsChargeStatus.fuelRangeElec, 852)
+        self.assertEqual(charging.rvsChargeStatus.mileage, 12345)
+        self.assertEqual(charging.rvsChargeStatus.chargingDuration, 150)
+        self.assertEqual(charging.rvsChargeStatus.totalBatteryCapacity, 508)
+        self.assertEqual(charging.rvsChargeStatus.mileageSinceLastCharge, 456)
+        self.assertFalse(
+            hasattr(charging.rvsChargeStatus, "powerUsageSinceLastCharge")
+        )
+        self.assertIsNone(_run(self.backend.get_charging_info("VIN1")))
+
+    def test_non_electric_status_does_not_wait_for_charge(self):
+        self.backend._electric_vins.clear()
+
+        _run(self.backend.get_vehicle_status("VIN1"))
+
+        self.assertFalse(self.fake.status_include_charge)
 
     def test_controls_delegate_to_client(self):
         _run(self.backend.lock_vehicle("VIN1"))
@@ -359,6 +386,19 @@ class FakeIndiaClient:
         self.logged_in = False
         self.vin = "VIN1"
         self.calls = []
+        self.status_include_charge = None
+        self.charge = types.SimpleNamespace(
+            is_charging=True,
+            is_plugged_in=True,
+            charging_voltage=360.0,
+            charging_current=16.0,
+            soc=62.5,
+            range_km=85.2,
+            odometer_km=1234.5,
+            charge_time_elapsed_s=90,
+            total_battery_capacity_kwh=50.8,
+            distance_since_last_charge_km=45.6,
+        )
 
     async def login(self):
         self.logged_in = True
@@ -375,7 +415,8 @@ class FakeIndiaClient:
             )
         ]
 
-    async def status(self):
+    async def status(self, include_charge=False):
+        self.status_include_charge = include_charge
         return types.SimpleNamespace(
             status_time=1_800_000_000,
             locked=True,
@@ -407,6 +448,7 @@ class FakeIndiaClient:
                     "frontRightSeatHeatLevel": 3,
                 }
             },
+            charge=self.charge,
         )
 
     async def control_door_lock(self, lock):

--- a/tests/test_india_gps.py
+++ b/tests/test_india_gps.py
@@ -184,8 +184,12 @@ def _load_modules():
         class _IndiaApiError(Exception):
             pass
 
+        class _ChargingStatusUnavailable(_IndiaApiError):
+            pass
+
         _module(
             "mg_ismart_india_client",
+            ChargingStatusUnavailable=_ChargingStatusUnavailable,
             MgIndiaApiError=_IndiaApiError,
             MgIndiaClient=object,
             hash_control_pin=lambda pin: pin,

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -133,8 +133,12 @@ def _load_modules():
         class _IndiaApiError(Exception):
             pass
 
+        class _ChargingStatusUnavailable(_IndiaApiError):
+            pass
+
         _module(
             "mg_ismart_india_client",
+            ChargingStatusUnavailable=_ChargingStatusUnavailable,
             MgIndiaApiError=_IndiaApiError,
             MgIndiaClient=object,
             hash_control_pin=lambda pin: pin,

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -264,13 +264,18 @@ class IndiaBEVStateOfChargeTests(unittest.TestCase):
         self.assertEqual(len(soc_entities), 1)
         self.assertEqual(soc_entities[0].native_value, 62)
         self.assertTrue(soc_entities[0].available)
-        self.assertFalse(
-            any(
-                isinstance(entity, SENSOR.SAICMGChargingSensor)
-                and entity._name == "Total Battery Capacity"
-                for entity in entities
-            )
-        )
+        # Total Battery Capacity is gated on CHARGING_DATA, which India now
+        # advertises, so the entity is created — but the India charging frame
+        # leaves totalBatteryCapacity absent in every capture seen so far, so
+        # it reads unknown rather than a fabricated number.
+        capacity = [
+            entity
+            for entity in entities
+            if isinstance(entity, SENSOR.SAICMGChargingSensor)
+            and entity._name == "Total Battery Capacity"
+        ]
+        self.assertEqual(len(capacity), 1)
+        self.assertIsNone(capacity[0].native_value)
 
     def test_status_soc_accepts_initial_zero(self):
         backend = INDIA.IndiaBackend("user", "password", vin="VIN1")


### PR DESCRIPTION
## Summary

- Expose India charging telemetry through the existing charging sensors.
- Pin `mg-ismart-india-client==0.1.7` and use its combined status/charging poll, so the TAP endpoint is called once per refresh.
- Wait for a charging frame only for detected electric VINs.
- Leave India `powerUsageSinceLastCharge` unset until its scale is confirmed.
- Keep non-BEV SOC separate from the India fuel-level field.

## Dependencies

- [x] [Client PR #7](https://github.com/john-lazarus/mg-ismart-india-client/pull/7) merged.
- [x] [Client 0.1.7](https://github.com/john-lazarus/mg-ismart-india-client/releases/tag/v0.1.7) published.
- [x] Standalone 0.1.6 bump in #323 closed as superseded; this PR carries the final dependency pin atomically.

## Coverage

The adapter coverage checks the single combined poll, charging-field mapping, one-use cached result, omitted unconfirmed energy field, and the non-electric status path.