### PR TITLE
feat(sensors): trip & efficiency statistics (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Mileage Since Last Charge
 - Efficiency Since Last Charge *(BEV/PHEV; km/kWh, derived from the two sensors above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
 - Last Trip Distance *(distance driven on the last completed drive)*
-- Last Trip Efficiency *(BEV/PHEV; km/kWh, with the full breakdown in its attributes)*
+- Last Trip Efficiency *(BEV/PHEV; switchable km/kWh · mi/kWh · kWh/100km, full breakdown in attributes)*
 - Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
 - Battery Heating Status *(if equipped)*
@@ -176,9 +176,10 @@ The integration derives per-trip and per-charge efficiency from data it already 
 The `Last Trip Efficiency` (BEV/PHEV) and `Last Trip Fuel Economy` (ICE/HEV/PHEV) sensors carry the full breakdown of the last drive in their **attributes**: distance, SOC used, energy in kWh, fuel used, duration, and both metric and mi/kWh figures. A `mg_saic_trip_completed` event also fires for each completed trip (with the same fields), so automations and the logbook can keep a full history without any single sensor holding a list.
 
 Notes and limitations:
+- **Units are switchable per entity.** The efficiency sensors use Home Assistant's `energy_distance` device class (HA 2025.2+), so you can switch each one between **km/kWh, mi/kWh and kWh/100km** in its settings — the same way Mileage switches between km and miles. On older HA they stay in km/kWh. Fuel economy is reported in **L/100km**; since HA has no fuel-consumption unit conversion, **UK and US mpg are provided in that sensor's attributes**.
 - SOC and fuel level are whole-number percentages, so figures for very short trips are coarse.
 - Trip *duration* is measured to the poll that detects shutdown, so treat it as approximate.
-- Fuel figures in litres / L per 100 km need a per-model tank size; until one is set for a given model, the fuel sensor reports **fuel % used** but not litres or L/100km.
+- Fuel figures in litres / L per 100 km need a per-model tank size; until one is set for a given model, the fuel sensor reports **fuel % used** but not litres, L/100km or mpg.
 - If the car is charged or refuelled while parked mid-trip, that trip's electric/fuel figure is omitted and flagged (`charged_during_park` / `refuelled_during_park`) rather than reported wrongly.
 
 ### BINARY SENSORS

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **To avoid issues, make sure to setup a Secondary Account on iSmart App.**
 
 **Requirements:**
-- Home Assistant 2024.06 or later.
+- Home Assistant 2025.2 or later.
 - Confirmed compatible with Python 3.14, the runtime used by current Home Assistant core releases (2026.3+). No action needed on your part this is handled automatically by Home Assistant on supported installation methods.
 
 ## INSTALLATION

--- a/README.md
+++ b/README.md
@@ -157,10 +157,30 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Added Electric Range
 - Power Usage Since Last Charge
 - Mileage Since Last Charge
+- Efficiency Since Last Charge *(BEV/PHEV; km/kWh, derived from the two sensors above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
+- Last Trip Distance *(distance driven on the last completed drive)*
+- Last Trip Efficiency *(BEV/PHEV; km/kWh, with the full breakdown in its attributes)*
+- Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
 - Battery Heating Status *(if equipped)*
 - Reachability *(is the car awake / likely asleep / unreachable — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
 - Data Freshness *(diagnostic: whether the last poll returned `live`, `cached` or `failed` data — see [Data Freshness sensor](#data-freshness-sensor))*
+### Trip & efficiency statistics
+
+The integration derives per-trip and per-charge efficiency from data it already collects — the odometer, state of charge, and (for combustion models) fuel level — so no extra setup is needed.
+
+**Efficiency Since Last Charge** *(BEV/PHEV)* comes straight from the car's own `Mileage Since Last Charge` and `Power Usage Since Last Charge` figures, so it's available immediately and needs no trip tracking.
+
+**Last Trip** sensors are populated when a drive ends. A trip is opened when the car powers on (the SAIC "vehicle start" message triggers a fresh reading) and closed when it powers off, so the start and end odometer/SOC/fuel are captured at the drive boundaries. Because the end is captured at shutdown — before any charging or refuelling — the energy and fuel figures aren't skewed by a top-up while parked.
+
+The `Last Trip Efficiency` (BEV/PHEV) and `Last Trip Fuel Economy` (ICE/HEV/PHEV) sensors carry the full breakdown of the last drive in their **attributes**: distance, SOC used, energy in kWh, fuel used, duration, and both metric and mi/kWh figures. A `mg_saic_trip_completed` event also fires for each completed trip (with the same fields), so automations and the logbook can keep a full history without any single sensor holding a list.
+
+Notes and limitations:
+- SOC and fuel level are whole-number percentages, so figures for very short trips are coarse.
+- Trip *duration* is measured to the poll that detects shutdown, so treat it as approximate.
+- Fuel figures in litres / L per 100 km need a per-model tank size; until one is set for a given model, the fuel sensor reports **fuel % used** but not litres or L/100km.
+- If the car is charged or refuelled while parked mid-trip, that trip's electric/fuel figure is omitted and flagged (`charged_during_park` / `refuelled_during_park`) rather than reported wrongly.
+
 ### BINARY SENSORS
  
 #### Doors

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -557,6 +557,7 @@ VEHICLE_PROFILES = {
         "max_temp": 28,
         "temp_offset": 2,
         "battery_capacity_kwh": 100.0,
+        "fuel_tank_litres": None,  # BEV — no fuel (mirrors DEFAULT)
         "climate_status_cool": {3},
         "climate_status_fan_only": {2},
         "fan_speed_low": 1,
@@ -582,6 +583,11 @@ DEFAULT_VEHICLE_PROFILE = {
     "max_temp": 28,
     "temp_offset": 2,
     "battery_capacity_kwh": None,
+    # Usable fuel-tank size in litres, for the ICE/PHEV per-trip fuel stats
+    # (#301). None -> the trip sensor reports fuel % used but not litres or
+    # L/100km. Populate per combustion model as tank sizes are confirmed
+    # (same approach as battery_capacity_kwh).
+    "fuel_tank_litres": None,
     "climate_status_cool": {3},
     "climate_status_fan_only": {2},
     # Fan byte values 4 and 5 are unsafe on the SAIC climate protocol — on

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -162,6 +162,9 @@ VEHICLE_PROFILES = {
         "max_temp": 30,
         "temp_offset": 2,
         "battery_capacity_kwh": None,
+        # MG3 Hybrid+ (HEV) petrol tank: 36 L (official spec, consistent across
+        # markets; the petrol-only MG3 is 45 L but isn't this series). (#301)
+        "fuel_tank_litres": 36.0,
         # start_ac reports remoteClimateStatus=2 while running — whether it is
         # heating or cooling (the car can't distinguish, it just drives to the
         # requested temperature). Map 2 to the on-state so the mode read-back
@@ -463,6 +466,8 @@ VEHICLE_PROFILES = {
         "supports_target_soc": True,
         "reliable_fuel_range_elec": True,
         "supports_charging_current_limit": True,
+        # MG S9 PHEV petrol tank: 65 L (official MG UK spec). (#301)
+        "fuel_tank_litres": 65.0,
         # --- mode_select climate scheme ---
         "climate_control_scheme": "mode_select",
         "climate_mode_fan_only": 1,
@@ -490,6 +495,14 @@ VEHICLE_PROFILES = {
         "max_temp": 28,
         "temp_offset": 2,
         "battery_capacity_kwh": 24.7,
+        # ⚠ MG HS PHEV petrol tank is MARKET-SPLIT (#301): UK/EU official spec is
+        # 37 L (MG UK dealer product guide), but the Australian "Super Hybrid" is
+        # 55 L (confirmed by multiple AU reviews/long-term tests). Same AS33P
+        # series either way, so we can't tell them apart from the API. Defaulting
+        # to the UK/EU 37 L (matches this integration's known UK reporters); AU
+        # owners should report it and we can revisit. Note some UK owners have
+        # also disputed 37 L, so this is a prime report-and-correct candidate.
+        "fuel_tank_litres": 37.0,
         "climate_status_cool": {3},
         "climate_status_fan_only": {2},
         "fan_speed_low": 1,

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -12,6 +12,7 @@ from .api import SAICMGAPIClient, CommandsLimitReachedException
 from .backends import Feature
 from .backends import backend_supports as _backend_supports
 from .logic import select_update_interval
+from .trip_stats import TripStatsManager, TripSnapshot
 
 # After the car turns off, fire extra refreshes at these intervals (seconds)
 # to catch plug-in as quickly as possible.  The coordinator is still on its
@@ -22,6 +23,9 @@ from .logic import select_update_interval
 POST_SHUTDOWN_REFRESH_SEQUENCE = [60, 120, 240, 480, 600]
 
 from .const import (
+    DATA_DECIMAL_CORRECTION,
+    DATA_DECIMAL_CORRECTION_SOC,
+    MILEAGE_UINT16_SATURATION,
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
     CONF_ABRP_API_KEY,
@@ -197,6 +201,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.max_temp = 28  # Default fallback
         self.temp_offset = 2  # Default fallback
         self.known_battery_capacity_kwh = None  # Set once series is detected
+        self.known_fuel_tank_litres = None  # Per-model tank size, for fuel stats (#301)
+        # Trip/efficiency stats manager (#301). Created and loaded in async_setup.
+        self.trip_stats = None
         # Climate control profile — set from VEHICLE_PROFILES on first data fetch.
         # Defaults match original integration behaviour so unrecognised models
         # continue to work as before.
@@ -710,6 +717,17 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         self.is_initial_setup = True
         vin = self.vin
 
+        # Trip/efficiency statistics (#301). Load the persisted open/last trip
+        # so a drive in progress survives a restart and the sensors repopulate.
+        try:
+            self.trip_stats = TripStatsManager(
+                self.hass, self.config_entry.entry_id, self.vin
+            )
+            await self.trip_stats.async_load()
+        except Exception as e:  # noqa: BLE001 - stats must never block setup
+            LOGGER.warning("Trip stats unavailable for VIN %s: %s", self.vin, e)
+            self.trip_stats = None
+
         # Restore last known values for activity and power-off times
         entity_id_last_activity = f"sensor.{DOMAIN}_{self.vin}_last_vehicle_activity"
         entity_id_last_power_off = f"sensor.{DOMAIN}_{self.vin}_last_powered_off"
@@ -816,6 +834,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.max_temp = profile["max_temp"]
             self.temp_offset = profile["temp_offset"]
             self.known_battery_capacity_kwh = profile["battery_capacity_kwh"]
+            self.known_fuel_tank_litres = profile.get("fuel_tank_litres")
             self.climate_status_cool = profile.get("climate_status_cool", {3})
             self.climate_status_fan_only = profile.get("climate_status_fan_only", {2})
             self.fan_speed_low = profile.get("fan_speed_low", 1)
@@ -1256,6 +1275,91 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.warning("ABRP telemetry failed for VIN %s: %s", self.vin, err)
 
     # Update Vehicle State
+    # ── Trip statistics (#301) ───────────────────────────────────────────────
+
+    def _trip_snapshot(self, basic_status, charging_data):
+        """Build a TripSnapshot from the current poll's data.
+
+        Mirrors the odometer/SOC extraction used by the mileage and SOC
+        sensors (decimal correction, uint16 saturation, -128 sentinels), so a
+        trip boundary reads the same numbers the user sees. Returns None if we
+        can't establish a valid odometer reading.
+        """
+        odometer = self._extract_odometer_km(basic_status, charging_data)
+        if odometer is None:
+            return None
+        return TripSnapshot(
+            ts=datetime.now(timezone.utc).isoformat(),
+            odometer_km=odometer,
+            soc_pct=self._extract_soc_pct(basic_status, charging_data),
+            fuel_pct=self._extract_fuel_pct(basic_status),
+        )
+
+    @staticmethod
+    def _extract_odometer_km(basic_status, charging_data):
+        """Odometer in km, or None. Rejects 0/-128 and the uint16 saturation."""
+        for source, factor in ((basic_status, DATA_DECIMAL_CORRECTION),):
+            raw = getattr(source, "mileage", None) if source is not None else None
+            if raw is not None and raw > 0 and raw != MILEAGE_UINT16_SATURATION:
+                return raw * factor
+        # Fall back to the wider odometer field in charging data.
+        chrg = getattr(charging_data, "chrgMgmtData", None) if charging_data else None
+        raw = getattr(chrg, "mileage", None) if chrg is not None else None
+        if raw is not None and raw > 0:
+            return raw * DATA_DECIMAL_CORRECTION
+        return None
+
+    @staticmethod
+    def _extract_soc_pct(basic_status, charging_data):
+        """SOC % from charging data (bmsPackSOCDsp), or None. Rejects -128."""
+        chrg = getattr(charging_data, "chrgMgmtData", None) if charging_data else None
+        raw = getattr(chrg, "bmsPackSOCDsp", None) if chrg is not None else None
+        if raw is not None and raw != -128:
+            return raw * DATA_DECIMAL_CORRECTION_SOC
+        return None
+
+    @staticmethod
+    def _extract_fuel_pct(basic_status):
+        """Fuel level % from basicVehicleStatus (0 is a valid reading), or None."""
+        raw = getattr(basic_status, "fuelLevelPrc", None) if basic_status else None
+        if raw is not None and 0 <= raw <= 100:
+            return float(raw)
+        return None
+
+    def _open_trip(self, basic_status, charging_data):
+        """Schedule opening a trip from the current snapshot (non-blocking)."""
+        if self.trip_stats is None:
+            return
+        snap = self._trip_snapshot(basic_status, charging_data)
+        if snap is None:
+            return
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self.trip_stats.open_trip(snap),
+            f"mg_saic_trip_open_{self.vin}",
+        )
+
+    def _close_trip(self, basic_status, charging_data):
+        """Schedule closing the open trip against the current snapshot."""
+        if self.trip_stats is None or self.trip_stats.open_snapshot is None:
+            return
+        snap = self._trip_snapshot(basic_status, charging_data)
+        if snap is None:
+            return
+        is_electric = self.vehicle_type in ("BEV", "PHEV")
+        is_combustion = self.vehicle_type in ("ICE", "HEV", "PHEV")
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self.trip_stats.close_trip(
+                snap,
+                capacity_kwh=self.known_battery_capacity_kwh,
+                tank_litres=self.known_fuel_tank_litres,
+                is_electric=is_electric,
+                is_combustion=is_combustion,
+            ),
+            f"mg_saic_trip_close_{self.vin}",
+        )
+
     def _update_state(self, data):
         """Update state variables based on fetched data."""
         status_data = data.get("status")
@@ -1281,6 +1385,8 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             if power_mode in [2, 3]:
                 if not self.is_powered_on:
                     self.last_powered_on_time = datetime.now(timezone.utc)
+                    # Trip start (#301): snapshot odometer/SOC/fuel now.
+                    self._open_trip(basic_status, charging_data)
                 self.is_powered_on = True
             else:
                 if self.is_powered_on:
@@ -1291,6 +1397,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                         self.vin,
                         "starting" if self.enable_shutdown_refresh_sequence else "skipping (disabled)",
                     )
+                    # Trip end (#301): close against this shutdown snapshot,
+                    # captured before any charging/refuelling begins.
+                    self._close_trip(basic_status, charging_data)
                     if self.enable_shutdown_refresh_sequence:
                         self._start_shutdown_refresh_sequence()
                 self.is_powered_on = False

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.5-beta1"
+  "version": "1.2.5-beta2"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3076,9 +3076,8 @@ class SAICMGClimateModeSensor(CoordinatorEntity, SensorEntity):
 
 # HA's energy_distance device class (added 2025.2) makes km/kWh sensors
 # user-switchable to mi/kWh or kWh/100km, exactly like the mileage sensor's
-# km<->mi conversion. getattr keeps us compatible with older HA (< 2025.2),
-# where the sensor simply stays fixed at km/kWh rather than erroring.
-ENERGY_DISTANCE_DEVICE_CLASS = getattr(SensorDeviceClass, "ENERGY_DISTANCE", None)
+# km<->mi conversion. Requires HA >= 2025.2 (enforced via hacs.json).
+ENERGY_DISTANCE_DEVICE_CLASS = SensorDeviceClass.ENERGY_DISTANCE
 
 # Keys copied into the efficiency sensors' attributes so a single entity
 # carries the full breakdown of the last trip.

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -665,7 +665,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     entry,
                     "Last Trip Efficiency",
                     "efficiency_km_per_kwh",
-                    None,
+                    ENERGY_DISTANCE_DEVICE_CLASS,
                     "km/kWh",
                     "mdi:gauge",
                     "measurement",
@@ -3074,6 +3074,12 @@ class SAICMGClimateModeSensor(CoordinatorEntity, SensorEntity):
 
 # ── Trip & efficiency statistics (#301) ──────────────────────────────────────
 
+# HA's energy_distance device class (added 2025.2) makes km/kWh sensors
+# user-switchable to mi/kWh or kWh/100km, exactly like the mileage sensor's
+# km<->mi conversion. getattr keeps us compatible with older HA (< 2025.2),
+# where the sensor simply stays fixed at km/kWh rather than erroring.
+ENERGY_DISTANCE_DEVICE_CLASS = getattr(SensorDeviceClass, "ENERGY_DISTANCE", None)
+
 # Keys copied into the efficiency sensors' attributes so a single entity
 # carries the full breakdown of the last trip.
 _TRIP_ATTR_KEYS = (
@@ -3087,6 +3093,8 @@ _TRIP_ATTR_KEYS = (
     "fuel_used_pct",
     "fuel_used_litres",
     "fuel_consumption_l_per_100km",
+    "fuel_economy_mpg_uk",
+    "fuel_economy_mpg_us",
     "charged_during_park",
     "refuelled_during_park",
     "start_ts",
@@ -3178,6 +3186,7 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._name = "Efficiency Since Last Charge"
         self._attr_icon = "mdi:gauge"
+        self._attr_device_class = ENERGY_DISTANCE_DEVICE_CLASS
         self._attr_native_unit_of_measurement = "km/kWh"
         self._attr_state_class = "measurement"
         vin_info = coordinator.vin_info

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -37,6 +37,7 @@ from .const import (
     DATA_100_DECIMAL_CORRECTION,
 )
 from .utils import create_device_info
+from .trip_stats import compute_since_charge_efficiency
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -643,6 +644,52 @@ async def async_setup_entry(hass, entry, async_add_entities):
             )
 
         # Add sensors
+        # Trip & efficiency statistics (#301). "Last Trip *" populate when a
+        # drive ends (power-off); the electric/fuel split follows the drivetrain.
+        sensors.append(
+            SAICMGLastTripSensor(
+                coordinator,
+                entry,
+                "Last Trip Distance",
+                "distance_km",
+                SensorDeviceClass.DISTANCE,
+                UnitOfLength.KILOMETERS,
+                "mdi:map-marker-distance",
+                "measurement",
+            )
+        )
+        if vehicle_type in ["BEV", "PHEV"]:
+            sensors.append(
+                SAICMGLastTripSensor(
+                    coordinator,
+                    entry,
+                    "Last Trip Efficiency",
+                    "efficiency_km_per_kwh",
+                    None,
+                    "km/kWh",
+                    "mdi:gauge",
+                    "measurement",
+                    with_attributes=True,
+                )
+            )
+            if coordinator.backend_supports(Feature.CHARGING_DATA):
+                sensors.append(
+                    SAICMGEfficiencySinceChargeSensor(coordinator, entry)
+                )
+        if vehicle_type in ["ICE", "HEV", "PHEV"]:
+            sensors.append(
+                SAICMGLastTripSensor(
+                    coordinator,
+                    entry,
+                    "Last Trip Fuel Economy",
+                    "fuel_consumption_l_per_100km",
+                    None,
+                    "L/100km",
+                    "mdi:gas-station",
+                    "measurement",
+                    with_attributes=True,
+                )
+            )
         sensors.append(SAICMGVehicleReachabilitySensor(coordinator, entry, vin_info, vin_info.vin))
         sensors.append(SAICMGDataFreshnessSensor(coordinator, entry, vin_info, vin_info.vin))
         sensors.append(SAICMGClimateModeSensor(coordinator, entry, vin_info, vin_info.vin))
@@ -3023,3 +3070,155 @@ class SAICMGClimateModeSensor(CoordinatorEntity, SensorEntity):
     def native_value(self):
         """Return the decoded climate mode (None when no status is available)."""
         return self.coordinator.climate_mode_from_status()
+
+
+# ── Trip & efficiency statistics (#301) ──────────────────────────────────────
+
+# Keys copied into the efficiency sensors' attributes so a single entity
+# carries the full breakdown of the last trip.
+_TRIP_ATTR_KEYS = (
+    "distance_km",
+    "duration_s",
+    "soc_used_pct",
+    "energy_kwh",
+    "efficiency_km_per_kwh",
+    "efficiency_mi_per_kwh",
+    "consumption_kwh_per_100km",
+    "fuel_used_pct",
+    "fuel_used_litres",
+    "fuel_consumption_l_per_100km",
+    "charged_during_park",
+    "refuelled_during_park",
+    "start_ts",
+    "end_ts",
+)
+
+
+class SAICMGLastTripSensor(CoordinatorEntity, SensorEntity):
+    """A single value from the last completed trip (#301).
+
+    Reads ``coordinator.trip_stats.last_trip`` — populated when a drive ends
+    (power-off transition). Optionally exposes the full trip breakdown as
+    attributes so one entity carries distance, energy, SOC used, etc.
+    """
+
+    def __init__(
+        self,
+        coordinator,
+        entry,
+        name,
+        key,
+        device_class,
+        unit,
+        icon,
+        state_class=None,
+        with_attributes=False,
+    ):
+        super().__init__(coordinator)
+        self._name = name
+        self._key = key
+        self._attr_device_class = device_class
+        self._attr_native_unit_of_measurement = unit
+        self._attr_icon = icon
+        self._attr_state_class = state_class
+        self._with_attributes = with_attributes
+        vin_info = coordinator.vin_info
+        self._unique_id = f"{entry.entry_id}_{vin_info.vin}_last_trip_{key}"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def name(self):
+        vin_info = self.coordinator.vin_info
+        return f"{vin_info.brandName} {vin_info.modelName} {self._name}"
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    def _trip(self):
+        stats = getattr(self.coordinator, "trip_stats", None)
+        return stats.last_trip if stats is not None else None
+
+    @property
+    def available(self):
+        trip = self._trip()
+        return trip is not None and trip.get(self._key) is not None
+
+    @property
+    def native_value(self):
+        trip = self._trip()
+        if trip is None:
+            return None
+        return trip.get(self._key)
+
+    @property
+    def extra_state_attributes(self):
+        if not self._with_attributes:
+            return None
+        trip = self._trip()
+        if not trip:
+            return None
+        return {k: trip.get(k) for k in _TRIP_ATTR_KEYS if trip.get(k) is not None}
+
+
+class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
+    """Electric efficiency since the last charge (#301).
+
+    Derived from the API's own ``mileageSinceLastCharge`` /
+    ``powerUsageSinceLastCharge`` (rvsChargeStatus), so it needs no persistence
+    or trip tracking — the car provides both distance and energy since the last
+    charge directly.
+    """
+
+    def __init__(self, coordinator, entry):
+        super().__init__(coordinator)
+        self._name = "Efficiency Since Last Charge"
+        self._attr_icon = "mdi:gauge"
+        self._attr_native_unit_of_measurement = "km/kWh"
+        self._attr_state_class = "measurement"
+        vin_info = coordinator.vin_info
+        self._unique_id = f"{entry.entry_id}_{vin_info.vin}_efficiency_since_charge"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def name(self):
+        vin_info = self.coordinator.vin_info
+        return f"{vin_info.brandName} {vin_info.modelName} {self._name}"
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    def _compute(self):
+        charging = self.coordinator.data.get("charging")
+        rcs = getattr(charging, "rvsChargeStatus", None) if charging else None
+        if rcs is None:
+            return None
+        dist_raw = getattr(rcs, "mileageSinceLastCharge", None)
+        energy_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
+        if dist_raw is None or energy_raw is None:
+            return None
+        return compute_since_charge_efficiency(
+            dist_raw * DATA_DECIMAL_CORRECTION, energy_raw * DATA_DECIMAL_CORRECTION
+        )
+
+    @property
+    def available(self):
+        return self._compute() is not None
+
+    @property
+    def native_value(self):
+        result = self._compute()
+        return None if result is None else result["efficiency_km_per_kwh"]
+
+    @property
+    def extra_state_attributes(self):
+        return self._compute()

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -130,6 +130,8 @@ def compute_completed_trip(
         "fuel_used_pct": None,
         "fuel_used_litres": None,
         "fuel_consumption_l_per_100km": None,
+        "fuel_economy_mpg_uk": None,
+        "fuel_economy_mpg_us": None,
         "refuelled_during_park": False,
     }
 
@@ -165,9 +167,13 @@ def compute_completed_trip(
                 litres = round(fuel_used / 100.0 * tank_litres, 2)
                 trip["fuel_used_litres"] = litres
                 if litres > 0:
-                    trip["fuel_consumption_l_per_100km"] = round(
-                        litres / distance_km * 100.0, 2
-                    )
+                    l_per_100km = round(litres / distance_km * 100.0, 2)
+                    trip["fuel_consumption_l_per_100km"] = l_per_100km
+                    if l_per_100km > 0:
+                        # HA has no fuel-consumption device class, so provide
+                        # mpg here for imperial users (both gallon definitions).
+                        trip["fuel_economy_mpg_uk"] = round(282.481 / l_per_100km, 1)
+                        trip["fuel_economy_mpg_us"] = round(235.215 / l_per_100km, 1)
 
     return trip
 

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -1,0 +1,298 @@
+# File: trip_stats.py
+"""Trip and efficiency statistics for MG SAIC vehicles (#301).
+
+This module derives per-trip statistics (distance, energy/fuel used, and
+efficiency) from the odometer, state-of-charge and fuel-level snapshots the
+coordinator already collects, plus the known battery capacity and (for
+combustion models) a per-model fuel-tank size.
+
+Design (see discussion #301)
+----------------------------
+The SAIC message queue fires a type-323 "vehicle start" message on every
+ignition-on, which the account poller turns into an immediate data refresh,
+so the coordinator sees a fresh odometer/SOC/fuel reading right at the start
+of a drive. There is no shutdown message, but the coordinator independently
+detects the power-on -> power-off transition (``is_powered_on``) on a poll
+and records ``last_powered_off_time``. So a trip is:
+
+    OPEN   on the power-on transition   -> snapshot (odometer, soc, fuel, ts)
+    CLOSE  on the power-off transition  -> snapshot again, compute the trip
+
+Closing on power-off (rather than on the *next* start) means the end SOC/fuel
+are captured before any charging or refuelling begins, which removes the
+"charged between drives" ambiguity for the energy maths.
+
+The maths in this file is deliberately pure and free of Home Assistant
+imports so it can be unit-tested directly. ``TripStatsManager`` wraps it with
+the HA ``Store`` persistence and event firing.
+
+Accuracy notes
+--------------
+* Distance (odometer delta) is exact once the car is off.
+* SOC and fuel level are integer percentages, so energy/fuel figures are
+  coarse for very short trips.
+* Trip *duration* is start-message time to power-off *detection* time, so it
+  can trail the real shutdown by up to a poll interval — treat as approximate.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Any
+
+# Reject an odometer delta larger than this (km) as a single trip — protects
+# against odometer rollover, the uint16 saturation sentinel slipping through,
+# or a garbage reading. A genuine single drive won't exceed this.
+MAX_PLAUSIBLE_TRIP_KM = 2000.0
+
+# Efficiency ratio helpers.
+KM_PER_MILE = 1.609344
+
+
+@dataclass
+class TripSnapshot:
+    """A single odometer/SOC/fuel reading taken at a trip boundary."""
+
+    ts: str  # ISO-8601 timestamp string (storage-friendly)
+    odometer_km: float
+    soc_pct: float | None = None
+    fuel_pct: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any] | None) -> "TripSnapshot | None":
+        if not d:
+            return None
+        try:
+            return cls(
+                ts=d["ts"],
+                odometer_km=float(d["odometer_km"]),
+                soc_pct=None if d.get("soc_pct") is None else float(d["soc_pct"]),
+                fuel_pct=None if d.get("fuel_pct") is None else float(d["fuel_pct"]),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def _duration_seconds(start_ts: str, end_ts: str) -> int | None:
+    try:
+        start = datetime.fromisoformat(start_ts)
+        end = datetime.fromisoformat(end_ts)
+    except (TypeError, ValueError):
+        return None
+    delta = (end - start).total_seconds()
+    if delta < 0:
+        return None
+    return int(delta)
+
+
+def compute_completed_trip(
+    start: TripSnapshot,
+    end: TripSnapshot,
+    *,
+    capacity_kwh: float | None,
+    tank_litres: float | None,
+    is_electric: bool,
+    is_combustion: bool,
+) -> dict[str, Any] | None:
+    """Compute a completed-trip dict from two boundary snapshots.
+
+    Returns ``None`` when the pair can't form a plausible trip (no movement,
+    implausibly large delta, or missing odometer). Individual electric/fuel
+    figures are set to ``None`` (not the whole trip) when their inputs are
+    missing or inconsistent (e.g. charged mid-park), so a valid distance-only
+    trip is still emitted.
+    """
+    if start is None or end is None:
+        return None
+
+    distance_km = round(end.odometer_km - start.odometer_km, 2)
+    # No movement, went backwards, or an implausible jump -> not a real trip.
+    if distance_km <= 0 or distance_km > MAX_PLAUSIBLE_TRIP_KM:
+        return None
+
+    trip: dict[str, Any] = {
+        "distance_km": distance_km,
+        "start_ts": start.ts,
+        "end_ts": end.ts,
+        "duration_s": _duration_seconds(start.ts, end.ts),
+        # Electric
+        "soc_used_pct": None,
+        "energy_kwh": None,
+        "efficiency_km_per_kwh": None,
+        "efficiency_mi_per_kwh": None,
+        "consumption_kwh_per_100km": None,
+        "charged_during_park": False,
+        # Fuel
+        "fuel_used_pct": None,
+        "fuel_used_litres": None,
+        "fuel_consumption_l_per_100km": None,
+        "refuelled_during_park": False,
+    }
+
+    # ── Electric portion (BEV/PHEV) ──────────────────────────────────────────
+    if is_electric and start.soc_pct is not None and end.soc_pct is not None:
+        soc_used = round(start.soc_pct - end.soc_pct, 1)
+        if soc_used < 0:
+            # SOC rose while parked/driving => charged in between. The delta no
+            # longer reflects consumption, so we don't report electric energy.
+            trip["charged_during_park"] = True
+        else:
+            trip["soc_used_pct"] = soc_used
+            if capacity_kwh:
+                energy = round(soc_used / 100.0 * capacity_kwh, 3)
+                trip["energy_kwh"] = energy
+                if energy > 0:
+                    trip["efficiency_km_per_kwh"] = round(distance_km / energy, 2)
+                    trip["efficiency_mi_per_kwh"] = round(
+                        (distance_km / KM_PER_MILE) / energy, 2
+                    )
+                    trip["consumption_kwh_per_100km"] = round(
+                        energy / distance_km * 100.0, 2
+                    )
+
+    # ── Fuel portion (ICE/HEV/PHEV) ──────────────────────────────────────────
+    if is_combustion and start.fuel_pct is not None and end.fuel_pct is not None:
+        fuel_used = round(start.fuel_pct - end.fuel_pct, 1)
+        if fuel_used < 0:
+            trip["refuelled_during_park"] = True
+        else:
+            trip["fuel_used_pct"] = fuel_used
+            if tank_litres:
+                litres = round(fuel_used / 100.0 * tank_litres, 2)
+                trip["fuel_used_litres"] = litres
+                if litres > 0:
+                    trip["fuel_consumption_l_per_100km"] = round(
+                        litres / distance_km * 100.0, 2
+                    )
+
+    return trip
+
+
+def compute_since_charge_efficiency(
+    distance_km: float | None, energy_kwh: float | None
+) -> dict[str, Any] | None:
+    """Efficiency from the API's own since-last-charge distance and energy.
+
+    Needs no persistence — both inputs come straight from the charging
+    endpoint (``mileageSinceLastCharge`` / ``powerUsageSinceLastCharge``).
+    """
+    if not distance_km or not energy_kwh or distance_km <= 0 or energy_kwh <= 0:
+        return None
+    return {
+        "distance_km": round(distance_km, 2),
+        "energy_kwh": round(energy_kwh, 3),
+        "efficiency_km_per_kwh": round(distance_km / energy_kwh, 2),
+        "efficiency_mi_per_kwh": round((distance_km / KM_PER_MILE) / energy_kwh, 2),
+        "consumption_kwh_per_100km": round(energy_kwh / distance_km * 100.0, 2),
+    }
+
+
+# ── Persistent manager ───────────────────────────────────────────────────────
+
+# HA imports are done lazily inside methods so the pure functions above can be
+# imported and unit-tested without Home Assistant installed.
+
+STORAGE_VERSION = 1
+EVENT_TRIP_COMPLETED = "mg_saic_trip_completed"
+
+
+class TripStatsManager:
+    """Owns the open/last trip state for one VIN and persists it across restarts.
+
+    Lifecycle:
+      * ``async_load`` once during coordinator setup.
+      * ``open_trip`` on the power-on transition.
+      * ``close_trip`` on the power-off transition -> stores ``last_trip``,
+        fires the ``mg_saic_trip_completed`` event, clears the open snapshot.
+
+    Only the *open* snapshot needs to survive a restart (so a trip in progress
+    isn't lost), plus the last completed trip so the sensors repopulate
+    immediately after a restart rather than showing Unknown.
+    """
+
+    def __init__(self, hass, entry_id: str, vin: str) -> None:
+        self._hass = hass
+        self._vin = vin
+        self._entry_id = entry_id
+        self._store = None  # created in async_load
+        self.open_snapshot: TripSnapshot | None = None
+        self.last_trip: dict[str, Any] | None = None
+
+    async def async_load(self) -> None:
+        from homeassistant.helpers.storage import Store
+
+        self._store = Store(
+            self._hass, STORAGE_VERSION, f"mg_saic_trips_{self._entry_id}_{self._vin}"
+        )
+        data = await self._store.async_load() or {}
+        self.open_snapshot = TripSnapshot.from_dict(data.get("open_snapshot"))
+        self.last_trip = data.get("last_trip")
+
+    async def _async_save(self) -> None:
+        if self._store is None:
+            return
+        await self._store.async_save(
+            {
+                "open_snapshot": (
+                    self.open_snapshot.to_dict() if self.open_snapshot else None
+                ),
+                "last_trip": self.last_trip,
+            }
+        )
+
+    async def open_trip(self, snapshot: TripSnapshot) -> None:
+        """Record the start-of-drive snapshot (idempotent-ish).
+
+        If a trip is already open we keep the *earlier* start — a duplicate
+        power-on/323 shouldn't reset the odometer baseline mid-drive.
+        """
+        if self.open_snapshot is not None:
+            return
+        self.open_snapshot = snapshot
+        await self._async_save()
+
+    async def close_trip(
+        self,
+        snapshot: TripSnapshot,
+        *,
+        capacity_kwh: float | None,
+        tank_litres: float | None,
+        is_electric: bool,
+        is_combustion: bool,
+    ) -> dict[str, Any] | None:
+        """Close the open trip against ``snapshot`` and return the trip dict.
+
+        Returns None (and leaves state cleared) if there was no open trip or
+        the pair didn't form a plausible trip.
+        """
+        start = self.open_snapshot
+        self.open_snapshot = None
+        if start is None:
+            await self._async_save()
+            return None
+
+        trip = compute_completed_trip(
+            start,
+            snapshot,
+            capacity_kwh=capacity_kwh,
+            tank_litres=tank_litres,
+            is_electric=is_electric,
+            is_combustion=is_combustion,
+        )
+        if trip is not None:
+            self.last_trip = trip
+            self._fire_event(trip)
+        await self._async_save()
+        return trip
+
+    def _fire_event(self, trip: dict[str, Any]) -> None:
+        try:
+            self._hass.bus.async_fire(
+                EVENT_TRIP_COMPLETED, {"vin": self._vin, **trip}
+            )
+        except Exception:  # noqa: BLE001 - event firing must never break a poll
+            pass

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "MG SAIC",
-  "homeassistant": "2024.06",
+  "homeassistant": "2025.2",
   "hacs": "1.33.0",
   "render_readme": true,
   "filename": "mg_saic.zip",

--- a/tests/test_india_gps.py
+++ b/tests/test_india_gps.py
@@ -102,6 +102,7 @@ def _load_modules():
             DISTANCE = "distance"
             DURATION = "duration"
             ENERGY = "energy"
+            ENERGY_DISTANCE = "energy_distance"
             ENUM = "enum"
             KILOMETERS = "km"
             KILOMETERS_PER_HOUR = "km/h"

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -1,0 +1,172 @@
+# File: tests/test_trip_stats.py
+"""Unit tests for the pure trip/efficiency maths in trip_stats (#301).
+
+These import only the pure functions, which have no Home Assistant deps, so
+they run in plain CPython with no stubs — matching the python-tests.yaml CI.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ts = _load("mg_saic_trip_stats_under_test", PKG_DIR / "trip_stats.py")
+Snap = ts.TripSnapshot
+
+
+def snap(odo, soc=None, fuel=None, t="2026-08-19T10:00:00+00:00"):
+    return Snap(ts=t, odometer_km=odo, soc_pct=soc, fuel_pct=fuel)
+
+
+class TestBevTrip(unittest.TestCase):
+    def test_basic_electric_trip(self):
+        start = snap(1000.0, soc=80.0, t="2026-08-19T10:00:00+00:00")
+        end = snap(1040.0, soc=70.0, t="2026-08-19T10:40:00+00:00")
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 40.0)
+        self.assertEqual(trip["soc_used_pct"], 10.0)
+        # 10% of 64 kWh = 6.4 kWh; 40 km / 6.4 = 6.25 km/kWh
+        self.assertAlmostEqual(trip["energy_kwh"], 6.4, places=3)
+        self.assertAlmostEqual(trip["efficiency_km_per_kwh"], 6.25, places=2)
+        self.assertAlmostEqual(trip["efficiency_mi_per_kwh"], 3.88, places=1)
+        self.assertAlmostEqual(trip["consumption_kwh_per_100km"], 16.0, places=1)
+        self.assertEqual(trip["duration_s"], 40 * 60)
+        self.assertFalse(trip["charged_during_park"])
+        # No fuel figures for a pure-electric trip.
+        self.assertIsNone(trip["fuel_used_litres"])
+
+    def test_charged_between_flags_and_skips_energy(self):
+        # SOC went UP (charged while parked before this drive's end reading).
+        start = snap(1000.0, soc=50.0)
+        end = snap(1010.0, soc=60.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 10.0)  # distance still valid
+        self.assertTrue(trip["charged_during_park"])
+        self.assertIsNone(trip["energy_kwh"])
+        self.assertIsNone(trip["efficiency_km_per_kwh"])
+
+    def test_missing_capacity_gives_distance_and_soc_only(self):
+        start = snap(1000.0, soc=80.0)
+        end = snap(1020.0, soc=75.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=None, tank_litres=None,
+            is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["soc_used_pct"], 5.0)
+        self.assertIsNone(trip["energy_kwh"])
+
+
+class TestIceTrip(unittest.TestCase):
+    def test_fuel_trip(self):
+        start = snap(500.0, fuel=90.0)
+        end = snap(560.0, fuel=80.0)  # used 10% of a 50 L tank = 5 L over 60 km
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=None, tank_litres=50.0,
+            is_electric=False, is_combustion=True,
+        )
+        self.assertEqual(trip["distance_km"], 60.0)
+        self.assertEqual(trip["fuel_used_pct"], 10.0)
+        self.assertAlmostEqual(trip["fuel_used_litres"], 5.0, places=2)
+        # 5 L / 60 km * 100 = 8.33 L/100km
+        self.assertAlmostEqual(trip["fuel_consumption_l_per_100km"], 8.33, places=1)
+        self.assertIsNone(trip["energy_kwh"])  # not electric
+
+    def test_refuelled_between_flags_and_skips_fuel(self):
+        start = snap(500.0, fuel=30.0)
+        end = snap(520.0, fuel=95.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=None, tank_litres=50.0,
+            is_electric=False, is_combustion=True,
+        )
+        self.assertTrue(trip["refuelled_during_park"])
+        self.assertIsNone(trip["fuel_used_litres"])
+
+
+class TestPhevTrip(unittest.TestCase):
+    def test_reports_both_electric_and_fuel(self):
+        start = snap(2000.0, soc=70.0, fuel=80.0)
+        end = snap(2050.0, soc=60.0, fuel=76.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=20.0, tank_litres=40.0,
+            is_electric=True, is_combustion=True,
+        )
+        self.assertEqual(trip["distance_km"], 50.0)
+        self.assertAlmostEqual(trip["energy_kwh"], 2.0, places=3)  # 10% of 20
+        self.assertAlmostEqual(trip["fuel_used_litres"], 1.6, places=2)  # 4% of 40
+
+
+class TestInvalidTrips(unittest.TestCase):
+    def test_zero_distance_is_not_a_trip(self):
+        self.assertIsNone(
+            ts.compute_completed_trip(
+                snap(1000.0, soc=80.0), snap(1000.0, soc=79.0),
+                capacity_kwh=64.0, tank_litres=None,
+                is_electric=True, is_combustion=False,
+            )
+        )
+
+    def test_backwards_odometer_is_not_a_trip(self):
+        self.assertIsNone(
+            ts.compute_completed_trip(
+                snap(1000.0), snap(990.0),
+                capacity_kwh=64.0, tank_litres=None,
+                is_electric=True, is_combustion=False,
+            )
+        )
+
+    def test_implausible_jump_rejected(self):
+        # Guards odometer rollover / saturation sentinel leaking through.
+        self.assertIsNone(
+            ts.compute_completed_trip(
+                snap(100.0), snap(100000.0),
+                capacity_kwh=64.0, tank_litres=None,
+                is_electric=True, is_combustion=False,
+            )
+        )
+
+
+class TestSinceChargeEfficiency(unittest.TestCase):
+    def test_basic(self):
+        r = ts.compute_since_charge_efficiency(100.0, 16.0)
+        self.assertAlmostEqual(r["efficiency_km_per_kwh"], 6.25, places=2)
+        self.assertAlmostEqual(r["consumption_kwh_per_100km"], 16.0, places=1)
+
+    def test_zero_or_missing_returns_none(self):
+        self.assertIsNone(ts.compute_since_charge_efficiency(0.0, 16.0))
+        self.assertIsNone(ts.compute_since_charge_efficiency(100.0, None))
+        self.assertIsNone(ts.compute_since_charge_efficiency(None, None))
+
+
+class TestSnapshotRoundTrip(unittest.TestCase):
+    def test_to_from_dict(self):
+        s = snap(1234.5, soc=55.0, fuel=None)
+        s2 = Snap.from_dict(s.to_dict())
+        self.assertEqual(s2.odometer_km, 1234.5)
+        self.assertEqual(s2.soc_pct, 55.0)
+        self.assertIsNone(s2.fuel_pct)
+
+    def test_from_dict_none_and_garbage(self):
+        self.assertIsNone(Snap.from_dict(None))
+        self.assertIsNone(Snap.from_dict({"odometer_km": "not-a-number"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -87,6 +87,9 @@ class TestIceTrip(unittest.TestCase):
         self.assertAlmostEqual(trip["fuel_used_litres"], 5.0, places=2)
         # 5 L / 60 km * 100 = 8.33 L/100km
         self.assertAlmostEqual(trip["fuel_consumption_l_per_100km"], 8.33, places=1)
+        # mpg for imperial users (HA can't convert L/100km automatically)
+        self.assertAlmostEqual(trip["fuel_economy_mpg_uk"], 33.9, places=1)
+        self.assertAlmostEqual(trip["fuel_economy_mpg_us"], 28.2, places=1)
         self.assertIsNone(trip["energy_kwh"])  # not electric
 
     def test_refuelled_between_flags_and_skips_fuel(self):

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -161,5 +161,34 @@ class TestBatteryCapacityOverridesAreSane(unittest.TestCase):
                 self.assertLess(capacity, 250.0, msg=f"{key} capacity too large")
 
 
+class TestFuelTankSizes(unittest.TestCase):
+    """#301: per-model fuel-tank litres for the combustion (ICE/HEV/PHEV) profiles."""
+
+    KNOWN = {
+        "ZP22": 36.0,   # MG3 Hybrid+ (HEV)
+        "IS31P": 65.0,  # MG S9 PHEV
+        "AS33P": 37.0,  # MG HS PHEV (UK/EU default; AU Super Hybrid is 55 L)
+    }
+
+    def test_known_tanks_populated(self):
+        for series, litres in self.KNOWN.items():
+            self.assertEqual(
+                const.VEHICLE_PROFILES[series].get("fuel_tank_litres"),
+                litres,
+                msg=f"{series} fuel_tank_litres should be {litres}",
+            )
+
+    def test_default_profile_has_no_tank(self):
+        # DEFAULT covers many unprofiled models, so it must not assume a size.
+        self.assertIsNone(const.DEFAULT_VEHICLE_PROFILE.get("fuel_tank_litres"))
+
+    def test_any_declared_tank_is_plausible(self):
+        for series, profile in const.VEHICLE_PROFILES.items():
+            litres = profile.get("fuel_tank_litres")
+            if litres is not None:
+                self.assertGreater(litres, 15.0, msg=f"{series} tank too small")
+                self.assertLess(litres, 120.0, msg=f"{series} tank too large")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Implements #301 — per-trip and per-charge efficiency statistics for BEV, PHEV, HEV and ICE, derived from data already collected (odometer, SOC, fuel level) plus known battery capacity and per-model fuel-tank sizes.

## Design
- **`trip_stats.py`** — a pure, HA-free computation core (fully unit-tested) plus `TripStatsManager`, which persists the open/last trip via `helpers.storage.Store` so a drive in progress survives a restart.
- **Event-driven boundaries** (per the #301 discussion): a trip opens on the coordinator's power-on transition (the SAIC type-323 vehicle-start message already forces a fresh poll) and closes on the power-off transition. Closing at shutdown captures end odometer/SOC/fuel *before* any charge or refuel, removing the "charged between drives" skew. Charge/refuel between drives is detected, flagged, and that figure omitted.
- Hooks live in `coordinator._update_state` at the existing `is_powered_on` transition; snapshot extraction mirrors the mileage/SOC sensor decoding (decimal correction, uint16 saturation, −128 sentinels).

## Sensors
- `Efficiency Since Last Charge` (BEV/PHEV) — from `mileageSinceLastCharge` / `powerUsageSinceLastCharge`; no persistence.
- `Last Trip Distance` (all), `Last Trip Efficiency` (BEV/PHEV), `Last Trip Fuel Economy` (ICE/HEV/PHEV) — efficiency sensors expose the full breakdown in attributes.
- A `mg_saic_trip_completed` HA event fires per trip, so history lives in the recorder/logbook rather than a sensor attribute list.

## Units (user-selectable)
- The electric-efficiency sensors use HA's `energy_distance` device class, so each is **switchable per entity between km/kWh, mi/kWh and kWh/100km** — same UX as the Mileage sensor's km↔mi.
- **This requires HA ≥ 2025.2** (bumped in `hacs.json` + README). The previous `getattr` fallback is removed, so the switcher is unconditional.
- Fuel economy stays **L/100km** (HA has no fuel-consumption device class); **UK and US mpg are provided in that sensor's attributes**.

## Per-model fuel tanks
`fuel_tank_litres` populated for the combustion profiles (fuel litres / L-per-100km / mpg compute only when set; corrected per model if owners report otherwise):
- **MG3 Hybrid+ (ZP22): 36 L**, **MG S9 PHEV (IS31P): 65 L** — official specs.
- **MG HS PHEV (AS33P): 37 L** — ⚠️ market-split: the Australian "Super Hybrid" is **55 L** on the same series. Defaults to the UK/EU figure; documented in-profile; AU owners to report.
- `DEFAULT` stays `None` (covers many unprofiled models → fuel % used only).

## Notes for review
- ⚠️ **Needs on-car validation** — the pure maths is tested, but the coordinator/sensor wiring hasn't been run against a live vehicle. Worth confirming snapshot field names per model and that the power-off close fires cleanly.
- **Breaking:** minimum HA is now 2025.2; HACS will stop offering updates to older installs.
- No translation changes: entity names are literal, not locale-keyed.
- Tests: `tests/test_trip_stats.py` (BEV/HEV/PHEV maths, charge/refuel-between guards, invalid-trip rejection, since-charge efficiency, snapshot round-trip) + fuel-tank profile tests. Full suite green (145).
- Manifest → `1.2.5-beta2`.
