### PR TITLE
fix(trip-stats): correct kWh attribute casing + add mile-equivalent attributes

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.5-beta2"
+  "version": "1.2.5-beta3"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -664,7 +664,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     coordinator,
                     entry,
                     "Last Trip Efficiency",
-                    "efficiency_km_per_kwh",
+                    "efficiency_km_per_kWh",
                     ENERGY_DISTANCE_DEVICE_CLASS,
                     "km/kWh",
                     "mdi:gauge",
@@ -682,7 +682,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                     coordinator,
                     entry,
                     "Last Trip Fuel Economy",
-                    "fuel_consumption_l_per_100km",
+                    "fuel_consumption_L_per_100km",
                     None,
                     "L/100km",
                     "mdi:gas-station",
@@ -3083,15 +3083,17 @@ ENERGY_DISTANCE_DEVICE_CLASS = SensorDeviceClass.ENERGY_DISTANCE
 # carries the full breakdown of the last trip.
 _TRIP_ATTR_KEYS = (
     "distance_km",
+    "distance_mi",
     "duration_s",
     "soc_used_pct",
-    "energy_kwh",
-    "efficiency_km_per_kwh",
-    "efficiency_mi_per_kwh",
-    "consumption_kwh_per_100km",
+    "energy_kWh",
+    "efficiency_km_per_kWh",
+    "efficiency_mi_per_kWh",
+    "consumption_kWh_per_100km",
+    "consumption_kWh_per_100mi",
     "fuel_used_pct",
     "fuel_used_litres",
-    "fuel_consumption_l_per_100km",
+    "fuel_consumption_L_per_100km",
     "fuel_economy_mpg_uk",
     "fuel_economy_mpg_us",
     "charged_during_park",
@@ -3225,7 +3227,7 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         result = self._compute()
-        return None if result is None else result["efficiency_km_per_kwh"]
+        return None if result is None else result["efficiency_km_per_kWh"]
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -116,20 +116,22 @@ def compute_completed_trip(
 
     trip: dict[str, Any] = {
         "distance_km": distance_km,
+        "distance_mi": round(distance_km / KM_PER_MILE, 2),
         "start_ts": start.ts,
         "end_ts": end.ts,
         "duration_s": _duration_seconds(start.ts, end.ts),
         # Electric
         "soc_used_pct": None,
-        "energy_kwh": None,
-        "efficiency_km_per_kwh": None,
-        "efficiency_mi_per_kwh": None,
-        "consumption_kwh_per_100km": None,
+        "energy_kWh": None,
+        "efficiency_km_per_kWh": None,
+        "efficiency_mi_per_kWh": None,
+        "consumption_kWh_per_100km": None,
+        "consumption_kWh_per_100mi": None,
         "charged_during_park": False,
         # Fuel
         "fuel_used_pct": None,
         "fuel_used_litres": None,
-        "fuel_consumption_l_per_100km": None,
+        "fuel_consumption_L_per_100km": None,
         "fuel_economy_mpg_uk": None,
         "fuel_economy_mpg_us": None,
         "refuelled_during_park": False,
@@ -146,14 +148,16 @@ def compute_completed_trip(
             trip["soc_used_pct"] = soc_used
             if capacity_kwh:
                 energy = round(soc_used / 100.0 * capacity_kwh, 3)
-                trip["energy_kwh"] = energy
+                trip["energy_kWh"] = energy
                 if energy > 0:
-                    trip["efficiency_km_per_kwh"] = round(distance_km / energy, 2)
-                    trip["efficiency_mi_per_kwh"] = round(
-                        (distance_km / KM_PER_MILE) / energy, 2
-                    )
-                    trip["consumption_kwh_per_100km"] = round(
+                    distance_mi = distance_km / KM_PER_MILE
+                    trip["efficiency_km_per_kWh"] = round(distance_km / energy, 2)
+                    trip["efficiency_mi_per_kWh"] = round(distance_mi / energy, 2)
+                    trip["consumption_kWh_per_100km"] = round(
                         energy / distance_km * 100.0, 2
+                    )
+                    trip["consumption_kWh_per_100mi"] = round(
+                        energy / distance_mi * 100.0, 2
                     )
 
     # ── Fuel portion (ICE/HEV/PHEV) ──────────────────────────────────────────
@@ -168,7 +172,7 @@ def compute_completed_trip(
                 trip["fuel_used_litres"] = litres
                 if litres > 0:
                     l_per_100km = round(litres / distance_km * 100.0, 2)
-                    trip["fuel_consumption_l_per_100km"] = l_per_100km
+                    trip["fuel_consumption_L_per_100km"] = l_per_100km
                     if l_per_100km > 0:
                         # HA has no fuel-consumption device class, so provide
                         # mpg here for imperial users (both gallon definitions).
@@ -188,12 +192,15 @@ def compute_since_charge_efficiency(
     """
     if not distance_km or not energy_kwh or distance_km <= 0 or energy_kwh <= 0:
         return None
+    distance_mi = distance_km / KM_PER_MILE
     return {
         "distance_km": round(distance_km, 2),
-        "energy_kwh": round(energy_kwh, 3),
-        "efficiency_km_per_kwh": round(distance_km / energy_kwh, 2),
-        "efficiency_mi_per_kwh": round((distance_km / KM_PER_MILE) / energy_kwh, 2),
-        "consumption_kwh_per_100km": round(energy_kwh / distance_km * 100.0, 2),
+        "distance_mi": round(distance_mi, 2),
+        "energy_kWh": round(energy_kwh, 3),
+        "efficiency_km_per_kWh": round(distance_km / energy_kwh, 2),
+        "efficiency_mi_per_kWh": round(distance_mi / energy_kwh, 2),
+        "consumption_kWh_per_100km": round(energy_kwh / distance_km * 100.0, 2),
+        "consumption_kWh_per_100mi": round(energy_kwh / distance_mi * 100.0, 2),
     }
 
 

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -41,10 +41,13 @@ class TestBevTrip(unittest.TestCase):
         self.assertEqual(trip["distance_km"], 40.0)
         self.assertEqual(trip["soc_used_pct"], 10.0)
         # 10% of 64 kWh = 6.4 kWh; 40 km / 6.4 = 6.25 km/kWh
-        self.assertAlmostEqual(trip["energy_kwh"], 6.4, places=3)
-        self.assertAlmostEqual(trip["efficiency_km_per_kwh"], 6.25, places=2)
-        self.assertAlmostEqual(trip["efficiency_mi_per_kwh"], 3.88, places=1)
-        self.assertAlmostEqual(trip["consumption_kwh_per_100km"], 16.0, places=1)
+        self.assertAlmostEqual(trip["energy_kWh"], 6.4, places=3)
+        self.assertAlmostEqual(trip["efficiency_km_per_kWh"], 6.25, places=2)
+        self.assertAlmostEqual(trip["efficiency_mi_per_kWh"], 3.88, places=1)
+        self.assertAlmostEqual(trip["consumption_kWh_per_100km"], 16.0, places=1)
+        # Mile-equivalent attributes
+        self.assertAlmostEqual(trip["distance_mi"], 24.85, places=1)  # 40 km
+        self.assertAlmostEqual(trip["consumption_kWh_per_100mi"], 25.75, places=1)
         self.assertEqual(trip["duration_s"], 40 * 60)
         self.assertFalse(trip["charged_during_park"])
         # No fuel figures for a pure-electric trip.
@@ -60,8 +63,8 @@ class TestBevTrip(unittest.TestCase):
         )
         self.assertEqual(trip["distance_km"], 10.0)  # distance still valid
         self.assertTrue(trip["charged_during_park"])
-        self.assertIsNone(trip["energy_kwh"])
-        self.assertIsNone(trip["efficiency_km_per_kwh"])
+        self.assertIsNone(trip["energy_kWh"])
+        self.assertIsNone(trip["efficiency_km_per_kWh"])
 
     def test_missing_capacity_gives_distance_and_soc_only(self):
         start = snap(1000.0, soc=80.0)
@@ -71,7 +74,7 @@ class TestBevTrip(unittest.TestCase):
             is_electric=True, is_combustion=False,
         )
         self.assertEqual(trip["soc_used_pct"], 5.0)
-        self.assertIsNone(trip["energy_kwh"])
+        self.assertIsNone(trip["energy_kWh"])
 
 
 class TestIceTrip(unittest.TestCase):
@@ -86,11 +89,11 @@ class TestIceTrip(unittest.TestCase):
         self.assertEqual(trip["fuel_used_pct"], 10.0)
         self.assertAlmostEqual(trip["fuel_used_litres"], 5.0, places=2)
         # 5 L / 60 km * 100 = 8.33 L/100km
-        self.assertAlmostEqual(trip["fuel_consumption_l_per_100km"], 8.33, places=1)
+        self.assertAlmostEqual(trip["fuel_consumption_L_per_100km"], 8.33, places=1)
         # mpg for imperial users (HA can't convert L/100km automatically)
         self.assertAlmostEqual(trip["fuel_economy_mpg_uk"], 33.9, places=1)
         self.assertAlmostEqual(trip["fuel_economy_mpg_us"], 28.2, places=1)
-        self.assertIsNone(trip["energy_kwh"])  # not electric
+        self.assertIsNone(trip["energy_kWh"])  # not electric
 
     def test_refuelled_between_flags_and_skips_fuel(self):
         start = snap(500.0, fuel=30.0)
@@ -112,7 +115,7 @@ class TestPhevTrip(unittest.TestCase):
             is_electric=True, is_combustion=True,
         )
         self.assertEqual(trip["distance_km"], 50.0)
-        self.assertAlmostEqual(trip["energy_kwh"], 2.0, places=3)  # 10% of 20
+        self.assertAlmostEqual(trip["energy_kWh"], 2.0, places=3)  # 10% of 20
         self.assertAlmostEqual(trip["fuel_used_litres"], 1.6, places=2)  # 4% of 40
 
 
@@ -149,8 +152,12 @@ class TestInvalidTrips(unittest.TestCase):
 class TestSinceChargeEfficiency(unittest.TestCase):
     def test_basic(self):
         r = ts.compute_since_charge_efficiency(100.0, 16.0)
-        self.assertAlmostEqual(r["efficiency_km_per_kwh"], 6.25, places=2)
-        self.assertAlmostEqual(r["consumption_kwh_per_100km"], 16.0, places=1)
+        self.assertAlmostEqual(r["efficiency_km_per_kWh"], 6.25, places=2)
+        self.assertAlmostEqual(r["consumption_kWh_per_100km"], 16.0, places=1)
+        # Mile equivalents present
+        self.assertAlmostEqual(r["distance_mi"], 62.14, places=1)
+        self.assertAlmostEqual(r["efficiency_mi_per_kWh"], 3.88, places=1)
+        self.assertAlmostEqual(r["consumption_kWh_per_100mi"], 25.75, places=1)
 
     def test_zero_or_missing_returns_none(self):
         self.assertIsNone(ts.compute_since_charge_efficiency(0.0, 16.0))


### PR DESCRIPTION
## Summary
Two small polish fixes to the trip/efficiency attributes from #301, spotted on a real MGS6 EV (`Efficiency Since Last Charge`):

1. **Correct `kWh` casing.** The attribute keys embedded `kwh`, which Home Assistant's attribute humaniser renders literally (e.g. *"Energy kwh"*, *"Efficiency km per kwh"*). Renamed to `kWh` casing so the labels read correctly, and capitalised the litres unit (`fuel_consumption_L_per_100km`).
2. **Add mile-equivalent attributes.** Previously only km-based attributes were exposed. Added `distance_mi` and `consumption_kWh_per_100mi` alongside the km ones (`efficiency_mi_per_kWh` already existed), so imperial users get the full breakdown without converting.

Both apply to `Last Trip Efficiency` and `Efficiency Since Last Charge`.

## Key renames
`energy_kwh`→`energy_kWh`, `efficiency_km_per_kwh`→`efficiency_km_per_kWh`, `efficiency_mi_per_kwh`→`efficiency_mi_per_kWh`, `consumption_kwh_per_100km`→`consumption_kWh_per_100km`, `fuel_consumption_l_per_100km`→`fuel_consumption_L_per_100km`.

⚠️ These are attribute-key renames. Anyone who wrote a template/automation against the beta keys (e.g. `state_attr(..., 'energy_kwh')`) will need to update to the new casing. This only affects the 1.2.5-beta trip sensors.

## Notes
- Sensor `native_value`/attribute references and `tests/test_trip_stats.py` updated; new assertions cover `distance_mi` and `consumption_kWh_per_100mi`. Full suite green (145).
- Verified the `Efficiency Since Last Charge` output reproduces the reported values (25 km / 3.8 kWh → 6.58 km/kWh, 4.09 mi/kWh, 15.2 kWh/100km) and now adds 15.53 mi and 24.46 kWh/100mi.
- Manifest → `1.2.5-beta3`.
