### PR TITLE
fix(trip-stats): open trips reliably — power_mode-driven, not is_powered_on transition (#301)

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1326,39 +1326,48 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             return float(raw)
         return None
 
-    def _open_trip(self, basic_status, charging_data):
-        """Schedule opening a trip from the current snapshot (non-blocking)."""
+    def _update_trip_state(self, power_mode, basic_status, charging_data):
+        """Open/close a trip based on the current power mode (#301).
+
+        Keyed off power_mode + whether a trip is already open — NOT the
+        is_powered_on transition, which the 323 start-message hint pre-sets
+        before the poll runs (so a transition-based hook would never fire an
+        open). This is also robust to HA restarts mid-drive and installing the
+        feature mid-drive. State is mutated synchronously; only the persist is
+        scheduled.
+        """
         if self.trip_stats is None:
             return
-        snap = self._trip_snapshot(basic_status, charging_data)
-        if snap is None:
-            return
-        self.config_entry.async_create_background_task(
-            self.hass,
-            self.trip_stats.open_trip(snap),
-            f"mg_saic_trip_open_{self.vin}",
-        )
+        driving = power_mode in (2, 3)
+        open_snap = self.trip_stats.open_snapshot
+        if driving and open_snap is None:
+            snap = self._trip_snapshot(basic_status, charging_data)
+            if snap is not None and self.trip_stats.open(snap):
+                LOGGER.debug("Trip opened for VIN %s at %s km", self.vin, snap.odometer_km)
+                self._schedule_trip_save()
+        elif not driving and open_snap is not None:
+            snap = self._trip_snapshot(basic_status, charging_data)
+            if snap is not None:
+                trip = self.trip_stats.close(
+                    snap,
+                    capacity_kwh=self.known_battery_capacity_kwh,
+                    tank_litres=self.known_fuel_tank_litres,
+                    is_electric=self.vehicle_type in ("BEV", "PHEV"),
+                    is_combustion=self.vehicle_type in ("ICE", "HEV", "PHEV"),
+                )
+                LOGGER.debug("Trip closed for VIN %s: %s", self.vin, trip)
+                self._schedule_trip_save()
 
-    def _close_trip(self, basic_status, charging_data):
-        """Schedule closing the open trip against the current snapshot."""
-        if self.trip_stats is None or self.trip_stats.open_snapshot is None:
-            return
-        snap = self._trip_snapshot(basic_status, charging_data)
-        if snap is None:
-            return
-        is_electric = self.vehicle_type in ("BEV", "PHEV")
-        is_combustion = self.vehicle_type in ("ICE", "HEV", "PHEV")
-        self.config_entry.async_create_background_task(
-            self.hass,
-            self.trip_stats.close_trip(
-                snap,
-                capacity_kwh=self.known_battery_capacity_kwh,
-                tank_litres=self.known_fuel_tank_litres,
-                is_electric=is_electric,
-                is_combustion=is_combustion,
-            ),
-            f"mg_saic_trip_close_{self.vin}",
-        )
+    def _schedule_trip_save(self):
+        """Persist trip state in the background (best-effort)."""
+        try:
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self.trip_stats.async_save(),
+                f"mg_saic_trip_save_{self.vin}",
+            )
+        except Exception as e:  # noqa: BLE001 - persistence must never break a poll
+            LOGGER.debug("Trip save scheduling failed for VIN %s: %s", self.vin, e)
 
     def _update_state(self, data):
         """Update state variables based on fetched data."""
@@ -1378,6 +1387,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
             power_mode = getattr(basic_status, "powerMode", None)
 
+            # Trip open/close (#301) — evaluated every poll from power_mode, so
+            # it's independent of the is_powered_on transition (which the 323
+            # start-message hint pre-sets before this poll runs).
+            self._update_trip_state(power_mode, basic_status, charging_data)
+
             # Detect Power State
             # Track previous state so we catch the transition even if a prior
             # poll returned None (generic response during power-down window)
@@ -1385,8 +1399,6 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             if power_mode in [2, 3]:
                 if not self.is_powered_on:
                     self.last_powered_on_time = datetime.now(timezone.utc)
-                    # Trip start (#301): snapshot odometer/SOC/fuel now.
-                    self._open_trip(basic_status, charging_data)
                 self.is_powered_on = True
             else:
                 if self.is_powered_on:
@@ -1397,9 +1409,6 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                         self.vin,
                         "starting" if self.enable_shutdown_refresh_sequence else "skipping (disabled)",
                     )
-                    # Trip end (#301): close against this shutdown snapshot,
-                    # captured before any charging/refuelling begins.
-                    self._close_trip(basic_status, charging_data)
                     if self.enable_shutdown_refresh_sequence:
                         self._start_shutdown_refresh_sequence()
                 self.is_powered_on = False

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.5-beta3"
+  "version": "1.2.5-beta4"
 }

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -218,9 +218,10 @@ class TripStatsManager:
 
     Lifecycle:
       * ``async_load`` once during coordinator setup.
-      * ``open_trip`` on the power-on transition.
-      * ``close_trip`` on the power-off transition -> stores ``last_trip``,
+      * ``open`` when a drive is detected (power_mode on) and no trip is open.
+      * ``close`` when the drive ends (power_mode off) -> stores ``last_trip``,
         fires the ``mg_saic_trip_completed`` event, clears the open snapshot.
+      * ``async_save`` persists after each open/close.
 
     Only the *open* snapshot needs to survive a restart (so a trip in progress
     isn't lost), plus the last completed trip so the sensors repopulate
@@ -245,7 +246,8 @@ class TripStatsManager:
         self.open_snapshot = TripSnapshot.from_dict(data.get("open_snapshot"))
         self.last_trip = data.get("last_trip")
 
-    async def _async_save(self) -> None:
+    async def async_save(self) -> None:
+        """Persist current open/last-trip state."""
         if self._store is None:
             return
         await self._store.async_save(
@@ -257,18 +259,21 @@ class TripStatsManager:
             }
         )
 
-    async def open_trip(self, snapshot: TripSnapshot) -> None:
-        """Record the start-of-drive snapshot (idempotent-ish).
+    def open(self, snapshot: TripSnapshot) -> bool:
+        """Record the start-of-drive snapshot (synchronous). Returns True if a
+        new trip was opened.
 
         If a trip is already open we keep the *earlier* start — a duplicate
-        power-on/323 shouldn't reset the odometer baseline mid-drive.
+        power-on shouldn't reset the odometer baseline mid-drive. Synchronous so
+        two rapid polls can't both open (the second sees open_snapshot set).
+        Callers persist via async_save afterwards.
         """
         if self.open_snapshot is not None:
-            return
+            return False
         self.open_snapshot = snapshot
-        await self._async_save()
+        return True
 
-    async def close_trip(
+    def close(
         self,
         snapshot: TripSnapshot,
         *,
@@ -277,15 +282,13 @@ class TripStatsManager:
         is_electric: bool,
         is_combustion: bool,
     ) -> dict[str, Any] | None:
-        """Close the open trip against ``snapshot`` and return the trip dict.
-
-        Returns None (and leaves state cleared) if there was no open trip or
-        the pair didn't form a plausible trip.
+        """Close the open trip against ``snapshot`` and return the trip dict
+        (synchronous). Returns None (and clears state) if there was no open trip
+        or the pair didn't form a plausible trip. Callers persist afterwards.
         """
         start = self.open_snapshot
         self.open_snapshot = None
         if start is None:
-            await self._async_save()
             return None
 
         trip = compute_completed_trip(
@@ -299,7 +302,6 @@ class TripStatsManager:
         if trip is not None:
             self.last_trip = trip
             self._fire_event(trip)
-        await self._async_save()
         return trip
 
     def _fire_event(self, trip: dict[str, Any]) -> None:

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -178,5 +178,55 @@ class TestSnapshotRoundTrip(unittest.TestCase):
         self.assertIsNone(Snap.from_dict({"odometer_km": "not-a-number"}))
 
 
+class TestManagerLifecycle(unittest.TestCase):
+    """TripStatsManager open/close state machine (sync parts, no HA Store)."""
+
+    def _mgr(self):
+        from unittest.mock import MagicMock
+
+        return ts.TripStatsManager(MagicMock(), "entry1", "VIN123")
+
+    def test_open_then_close_produces_last_trip(self):
+        m = self._mgr()
+        self.assertTrue(m.open(snap(1000.0, soc=80.0)))
+        self.assertIsNotNone(m.open_snapshot)
+        trip = m.close(
+            snap(1040.0, soc=70.0), capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False,
+        )
+        self.assertIsNotNone(trip)
+        self.assertEqual(trip["distance_km"], 40.0)
+        self.assertEqual(m.last_trip["distance_km"], 40.0)
+        self.assertIsNone(m.open_snapshot)  # cleared after close
+
+    def test_open_is_idempotent_keeps_first_start(self):
+        m = self._mgr()
+        self.assertTrue(m.open(snap(1000.0, soc=80.0)))
+        # A second open while one is in progress is ignored (keeps the baseline).
+        self.assertFalse(m.open(snap(1010.0, soc=78.0)))
+        self.assertEqual(m.open_snapshot.odometer_km, 1000.0)
+
+    def test_close_with_no_open_trip_returns_none(self):
+        m = self._mgr()
+        self.assertIsNone(
+            m.close(
+                snap(1040.0, soc=70.0), capacity_kwh=64.0, tank_litres=None,
+                is_electric=True, is_combustion=False,
+            )
+        )
+        self.assertIsNone(m.last_trip)
+
+    def test_zero_distance_trip_not_stored_but_open_cleared(self):
+        m = self._mgr()
+        m.open(snap(1000.0, soc=80.0))
+        trip = m.close(
+            snap(1000.0, soc=79.0), capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False,
+        )
+        self.assertIsNone(trip)      # not a real trip
+        self.assertIsNone(m.last_trip)
+        self.assertIsNone(m.open_snapshot)  # still cleared so the next drive opens fresh
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes the trip sensors from #301 staying **Unavailable** after a full drive. Reported on a live MGS6 EV: `Last Trip Distance` / `Last Trip Efficiency` never populated, while `Efficiency Since Last Charge` worked fine.

## Root cause
A trip was never *opened*, so power-off had nothing to close. The open hook fired only on the `is_powered_on` False→True transition inside `_update_state` — but `hint_vehicle_started` (triggered by the SAIC type-323 vehicle-start message) pre-sets `is_powered_on = True` **before** that poll runs. So the transition never happened in `_update_state`, and the open never fired. The since-charge sensor was unaffected because it recomputes live from the charging data every poll.

## Fix
Drive trip open/close from `power_mode` on every poll, keyed on whether a trip is already open (`open_snapshot`) — independent of the `is_powered_on` transition:
- `power_mode in (2, 3)` and no open trip → **open** (snapshot odometer/SOC/fuel)
- `power_mode == 0` and a trip is open → **close**

This is also robust to HA restarts mid-drive, installing the feature mid-drive, and missed start messages. Manager `open()`/`close()` are now synchronous state mutations (so two rapid polls can't double-open — the second sees `open_snapshot` already set), with a separate `async_save()` for persistence. The old transition-based hooks are removed.

## Verified against the reporter's live HA
Snapshot extraction reads the right fields and units — the only thing broken was the open path:
- Mileage 2129.4 mi (34270 × 0.1 km), SOC 71.9% (719 × 0.1), since-charge 37 km / 5.8 kWh — all consistent with the coordinator data.

## Tests
Adds `TripStatsManager` lifecycle tests (open→close produces last_trip, idempotent open keeps the first start, close-with-no-open returns None, zero-distance clears the open snapshot). Full suite green (149).

Manifest → `1.2.5-beta4`.
