### PR TITLE
fix(trip-stats): SOC fallback + Unknown (not Unavailable) for efficiency sensors (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Notes and limitations:
 - Trip *duration* is measured to the poll that detects shutdown, so treat it as approximate.
 - Fuel figures in litres / L per 100 km need a per-model tank size; until one is set for a given model, the fuel sensor reports **fuel % used** but not litres, L/100km or mpg.
 - If the car is charged or refuelled while parked mid-trip, that trip's electric/fuel figure is omitted and flagged (`charged_during_park` / `refuelled_during_park`) rather than reported wrongly.
+- When a value can't be computed yet, the efficiency sensors read **Unknown** rather than Unavailable — e.g. `Efficiency Since Last Charge` while charging or right after a charge (0 km driven since), or `Last Trip Efficiency` for a trip where a charge spanned the drive. The sensor's attributes still show the breakdown so you can see why.
 
 ### BINARY SENSORS
  

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1311,11 +1311,19 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _extract_soc_pct(basic_status, charging_data):
-        """SOC % from charging data (bmsPackSOCDsp), or None. Rejects -128."""
+        """SOC % — charging bmsPackSOCDsp (×0.1), else basic extendedData1 (int %).
+
+        Mirrors the SOC sensor's own fallback so a momentary charging-endpoint
+        dropout doesn't leave a trip snapshot with no SOC — which would drop the
+        whole trip's efficiency (energy needs a start AND end SOC).
+        """
         chrg = getattr(charging_data, "chrgMgmtData", None) if charging_data else None
         raw = getattr(chrg, "bmsPackSOCDsp", None) if chrg is not None else None
         if raw is not None and raw != -128:
             return raw * DATA_DECIMAL_CORRECTION_SOC
+        raw = getattr(basic_status, "extendedData1", None) if basic_status else None
+        if raw is not None and raw not in (-128, -1):
+            return float(raw)
         return None
 
     @staticmethod

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.5-beta4"
+  "version": "1.2.5-beta5"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3154,8 +3154,12 @@ class SAICMGLastTripSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self):
-        trip = self._trip()
-        return trip is not None and trip.get(self._key) is not None
+        # Stay available and show "unknown" (rather than "unavailable") when
+        # this trip has no value for the key — e.g. no efficiency because a
+        # charge spanned the trip, or SOC was missing. Cleaner than dropping the
+        # entity out of dashboards/history; the sensor is working, it just has
+        # no value for this trip.
+        return True
 
     @property
     def native_value(self):
@@ -3222,7 +3226,11 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self):
-        return self._compute() is not None
+        # Show "unknown" (not "unavailable") when there's nothing to compute
+        # yet — e.g. while charging or right after a charge, when 0 km have been
+        # driven since the last charge. The sensor is working; it just has no
+        # value at this moment, so keep it present rather than dropping it out.
+        return True
 
     @property
     def native_value(self):


### PR DESCRIPTION
## Summary
Two related fixes for the trip/efficiency sensors from #301, both seen on a live MGS6 EV where `Last Trip Efficiency` and `Efficiency Since Last Charge` were dropping to **Unavailable**.

## 1. SOC fallback — the real cause of Last Trip Efficiency going Unavailable
Trip snapshots read SOC only from the charging endpoint (`bmsPackSOCDsp`), which blips out intermittently (the same SAIC charging-endpoint dropout tracked in #262). When SOC is missing at the trip's start or end, the electric-energy figure can't be computed, so the trip records a **distance but no efficiency** — the distance sensor updates while the efficiency sensor goes Unavailable (exactly the reported symptom: "only efficiency isn't working").

`_extract_soc_pct` now falls back to `basicVehicleStatus.extendedData1` (integer %) — the *same* fallback the main SOC sensor already uses — so a trip's efficiency survives a momentary charging-endpoint dropout.

## 2. Unknown instead of Unavailable
The efficiency sensors now stay available and read **Unknown** when there's genuinely no value yet, instead of Unavailable:
- **Efficiency Since Last Charge** while charging or right after a charge (0 km driven since the last charge) — this is the "goes unavailable when charging" report.
- **Last Trip Efficiency** for a trip that a charge spanned (no meaningful electric figure).

Unknown keeps the entity in dashboards and history (Unavailable drops it out), and — unlike Unavailable — the **attributes stay visible**, so the breakdown (`charged_during_park`, `soc_used_pct`, etc.) explains *why* there's no value.

## Verified against live HA
- The efficiency sensor had recorded a valid trip earlier (14 km, 5.89 km/kWh) but a later ~11 km trip closed with distance only and efficiency Unavailable — consistent with a missing SOC reading at a boundary. Charging-endpoint blips confirmed (Efficiency Since Last Charge Unavailable while charging).

## Notes
- README updated. Full suite green (149). Manifest → `1.2.5-beta5`.
