### PR TITLE
feat(trip-stats): derive trip distance/energy from the car's since-charge counters (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The integration derives per-trip and per-charge efficiency from data it already 
 
 **Efficiency Since Last Charge** *(BEV/PHEV)* comes straight from the car's own `Mileage Since Last Charge` and `Power Usage Since Last Charge` figures, so it's available immediately and needs no trip tracking.
 
-**Last Trip** sensors are populated when a drive ends. A trip is opened when the car powers on (the SAIC "vehicle start" message triggers a fresh reading) and closed when it powers off, so the start and end odometer/SOC/fuel are captured at the drive boundaries. Because the end is captured at shutdown — before any charging or refuelling — the energy and fuel figures aren't skewed by a top-up while parked.
+**Last Trip** sensors are populated when a drive ends (the car powers off). Distance and electric energy come from the car's own cumulative counters (`Mileage Since Last Charge` / `Power Usage Since Last Charge`), diffed between one trip and the next — so they match the car's own measurements and don't depend on exactly when the trip was detected. (For non-charging models, distance falls back to the odometer.) A charge between trips is handled automatically (the counters reset). A trip is one power-on to power-off, so a journey with a stop in the middle counts as two trips.
 
 The `Last Trip Efficiency` (BEV/PHEV) and `Last Trip Fuel Economy` (ICE/HEV/PHEV) sensors carry the full breakdown of the last drive in their **attributes**: distance, SOC used, energy in kWh, fuel used, duration, and both metric and mi/kWh figures. A `mg_saic_trip_completed` event also fires for each completed trip (with the same fields), so automations and the logbook can keep a full history without any single sensor holding a list.
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1288,12 +1288,29 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         odometer = self._extract_odometer_km(basic_status, charging_data)
         if odometer is None:
             return None
+        km, kwh = self._extract_since_charge(charging_data)
         return TripSnapshot(
             ts=datetime.now(timezone.utc).isoformat(),
             odometer_km=odometer,
             soc_pct=self._extract_soc_pct(basic_status, charging_data),
             fuel_pct=self._extract_fuel_pct(basic_status),
+            since_charge_km=km,
+            since_charge_kwh=kwh,
         )
+
+    @staticmethod
+    def _extract_since_charge(charging_data):
+        """(distance_km, energy_kWh) since last charge from rvsChargeStatus, or
+        (None, None). The car's own cumulative counters — preferred source for
+        trip distance/energy (see trip_stats.compute_completed_trip)."""
+        rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
+        if rcs is None:
+            return None, None
+        km_raw = getattr(rcs, "mileageSinceLastCharge", None)
+        kwh_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
+        km = km_raw * DATA_DECIMAL_CORRECTION if km_raw is not None and km_raw >= 0 else None
+        kwh = kwh_raw * DATA_DECIMAL_CORRECTION if kwh_raw is not None and kwh_raw >= 0 else None
+        return km, kwh
 
     @staticmethod
     def _extract_odometer_km(basic_status, charging_data):
@@ -1346,6 +1363,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if self.trip_stats is None:
             return
+        # Track the since-charge counters every poll so a charge reset is caught
+        # promptly and the next trip's distance/energy baseline is correct.
+        km, kwh = self._extract_since_charge(charging_data)
+        if self.trip_stats.note_since_charge(km, kwh):
+            self._schedule_trip_save()
         driving = power_mode in (2, 3)
         open_snap = self.trip_stats.open_snapshot
         if driving and open_snap is None:

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.5-beta5"
+  "version": "1.2.5-beta6"
 }

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -52,12 +52,22 @@ KM_PER_MILE = 1.609344
 
 @dataclass
 class TripSnapshot:
-    """A single odometer/SOC/fuel reading taken at a trip boundary."""
+    """A single reading taken at a trip boundary.
+
+    Carries both the raw odometer/SOC/fuel (fallback) and the car's own
+    cumulative since-last-charge counters, which are the preferred source for
+    distance and electric energy — see compute_completed_trip.
+    """
 
     ts: str  # ISO-8601 timestamp string (storage-friendly)
     odometer_km: float
     soc_pct: float | None = None
     fuel_pct: float | None = None
+    # Car's cumulative counters since the last charge (reset to ~0 at each
+    # charge). Preferred for distance/energy because they're the car's own
+    # measurements and don't depend on when the trip snapshot was taken.
+    since_charge_km: float | None = None
+    since_charge_kwh: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -66,12 +76,19 @@ class TripSnapshot:
     def from_dict(cls, d: dict[str, Any] | None) -> "TripSnapshot | None":
         if not d:
             return None
+
+        def _f(key):
+            v = d.get(key)
+            return None if v is None else float(v)
+
         try:
             return cls(
                 ts=d["ts"],
                 odometer_km=float(d["odometer_km"]),
-                soc_pct=None if d.get("soc_pct") is None else float(d["soc_pct"]),
-                fuel_pct=None if d.get("fuel_pct") is None else float(d["fuel_pct"]),
+                soc_pct=_f("soc_pct"),
+                fuel_pct=_f("fuel_pct"),
+                since_charge_km=_f("since_charge_km"),
+                since_charge_kwh=_f("since_charge_kwh"),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -89,34 +106,60 @@ def _duration_seconds(start_ts: str, end_ts: str) -> int | None:
     return int(delta)
 
 
+def _counter_delta(current, baseline_value):
+    """Delta of a cumulative since-charge counter against the last-close
+    baseline. If it went backwards, the counter reset (a charge happened since
+    the last close), so the current value IS the delta. Returns None if the
+    current value is unavailable.
+    """
+    if current is None:
+        return None
+    if baseline_value is None or current < baseline_value:
+        return round(current, 3)
+    return round(current - baseline_value, 3)
+
+
 def compute_completed_trip(
     start: TripSnapshot,
     end: TripSnapshot,
     *,
+    baseline: dict[str, Any] | None = None,
     capacity_kwh: float | None,
     tank_litres: float | None,
     is_electric: bool,
     is_combustion: bool,
 ) -> dict[str, Any] | None:
-    """Compute a completed-trip dict from two boundary snapshots.
+    """Compute a completed-trip dict for the drive ending at ``end``.
 
-    Returns ``None`` when the pair can't form a plausible trip (no movement,
-    implausibly large delta, or missing odometer). Individual electric/fuel
-    figures are set to ``None`` (not the whole trip) when their inputs are
-    missing or inconsistent (e.g. charged mid-park), so a valid distance-only
-    trip is still emitted.
+    Distance and electric energy come from the car's own cumulative counters
+    (``mileageSinceLastCharge`` / ``powerUsageSinceLastCharge``) diffed against
+    ``baseline`` — the counter values at the previous trip's close (or ~0 after
+    a charge). This is the car's own measurement and, crucially, doesn't depend
+    on when the trip's *open* snapshot was taken, so a late/fragmented open no
+    longer skews the numbers. Falls back to the odometer delta (and SOC×capacity
+    for energy) when the counters aren't available (e.g. non-charging models, or
+    a charging-endpoint dropout).
+
+    Returns ``None`` when no plausible distance can be established. Individual
+    electric/fuel figures are ``None`` when their inputs are missing.
     """
     if start is None or end is None:
         return None
 
-    distance_km = round(end.odometer_km - start.odometer_km, 2)
-    # No movement, went backwards, or an implausible jump -> not a real trip.
+    base_km = baseline.get("since_charge_km") if baseline else None
+    base_kwh = baseline.get("since_charge_kwh") if baseline else None
+
+    # ── Distance: prefer the since-charge counter, else the odometer delta ────
+    distance_km = _counter_delta(end.since_charge_km, base_km)
+    if distance_km is None:
+        distance_km = round(end.odometer_km - start.odometer_km, 2)
     if distance_km <= 0 or distance_km > MAX_PLAUSIBLE_TRIP_KM:
         return None
 
+    distance_mi = distance_km / KM_PER_MILE
     trip: dict[str, Any] = {
-        "distance_km": distance_km,
-        "distance_mi": round(distance_km / KM_PER_MILE, 2),
+        "distance_km": round(distance_km, 2),
+        "distance_mi": round(distance_mi, 2),
         "start_ts": start.ts,
         "end_ts": end.ts,
         "duration_s": _duration_seconds(start.ts, end.ts),
@@ -137,30 +180,26 @@ def compute_completed_trip(
         "refuelled_during_park": False,
     }
 
-    # ── Electric portion (BEV/PHEV) ──────────────────────────────────────────
-    if is_electric and start.soc_pct is not None and end.soc_pct is not None:
-        soc_used = round(start.soc_pct - end.soc_pct, 1)
-        if soc_used < 0:
-            # SOC rose while parked/driving => charged in between. The delta no
-            # longer reflects consumption, so we don't report electric energy.
-            trip["charged_during_park"] = True
-        else:
-            trip["soc_used_pct"] = soc_used
-            if capacity_kwh:
-                energy = round(soc_used / 100.0 * capacity_kwh, 3)
-                trip["energy_kWh"] = energy
-                if energy > 0:
-                    distance_mi = distance_km / KM_PER_MILE
-                    trip["efficiency_km_per_kWh"] = round(distance_km / energy, 2)
-                    trip["efficiency_mi_per_kWh"] = round(distance_mi / energy, 2)
-                    trip["consumption_kWh_per_100km"] = round(
-                        energy / distance_km * 100.0, 2
-                    )
-                    trip["consumption_kWh_per_100mi"] = round(
-                        energy / distance_mi * 100.0, 2
-                    )
+    # ── Electric energy (BEV/PHEV) ───────────────────────────────────────────
+    if is_electric:
+        energy = _counter_delta(end.since_charge_kwh, base_kwh)
+        if energy is None and start.soc_pct is not None and end.soc_pct is not None:
+            # Fallback: derive from SOC change (coarse; only when no counter).
+            soc_used = round(start.soc_pct - end.soc_pct, 1)
+            if soc_used < 0:
+                trip["charged_during_park"] = True
+            else:
+                trip["soc_used_pct"] = soc_used
+                if capacity_kwh:
+                    energy = round(soc_used / 100.0 * capacity_kwh, 3)
+        if energy is not None and energy > 0:
+            trip["energy_kWh"] = round(energy, 3)
+            trip["efficiency_km_per_kWh"] = round(distance_km / energy, 2)
+            trip["efficiency_mi_per_kWh"] = round(distance_mi / energy, 2)
+            trip["consumption_kWh_per_100km"] = round(energy / distance_km * 100.0, 2)
+            trip["consumption_kWh_per_100mi"] = round(energy / distance_mi * 100.0, 2)
 
-    # ── Fuel portion (ICE/HEV/PHEV) ──────────────────────────────────────────
+    # ── Fuel (ICE/HEV/PHEV) ──────────────────────────────────────────────────
     if is_combustion and start.fuel_pct is not None and end.fuel_pct is not None:
         fuel_used = round(start.fuel_pct - end.fuel_pct, 1)
         if fuel_used < 0:
@@ -235,6 +274,10 @@ class TripStatsManager:
         self._store = None  # created in async_load
         self.open_snapshot: TripSnapshot | None = None
         self.last_trip: dict[str, Any] | None = None
+        # Since-charge counter values at the last trip close (rebased to ~0 when
+        # a charge resets the counter). Distance/energy for the next trip diff
+        # against this — see note_since_charge / close.
+        self.since_charge_baseline: dict[str, Any] | None = None
 
     async def async_load(self) -> None:
         from homeassistant.helpers.storage import Store
@@ -245,9 +288,10 @@ class TripStatsManager:
         data = await self._store.async_load() or {}
         self.open_snapshot = TripSnapshot.from_dict(data.get("open_snapshot"))
         self.last_trip = data.get("last_trip")
+        self.since_charge_baseline = data.get("since_charge_baseline")
 
     async def async_save(self) -> None:
-        """Persist current open/last-trip state."""
+        """Persist current open/last-trip state and the since-charge baseline."""
         if self._store is None:
             return
         await self._store.async_save(
@@ -256,8 +300,32 @@ class TripStatsManager:
                     self.open_snapshot.to_dict() if self.open_snapshot else None
                 ),
                 "last_trip": self.last_trip,
+                "since_charge_baseline": self.since_charge_baseline,
             }
         )
+
+    def note_since_charge(self, km, kwh) -> bool:
+        """Track the since-charge counters each poll to catch a charge reset.
+
+        When the counter drops below the stored baseline, a charge has zeroed it,
+        so rebase to the new low. Returns True if the baseline changed (caller
+        may persist). Called every poll from the coordinator.
+        """
+        if km is None:
+            return False
+        if self.since_charge_baseline is None:
+            self.since_charge_baseline = {
+                "since_charge_km": round(km, 3),
+                "since_charge_kwh": round(kwh, 3) if kwh is not None else 0.0,
+            }
+            return True
+        if km < self.since_charge_baseline.get("since_charge_km", 0.0):
+            self.since_charge_baseline = {
+                "since_charge_km": round(km, 3),
+                "since_charge_kwh": round(kwh, 3) if kwh is not None else 0.0,
+            }
+            return True
+        return False
 
     def open(self, snapshot: TripSnapshot) -> bool:
         """Record the start-of-drive snapshot (synchronous). Returns True if a
@@ -294,11 +362,23 @@ class TripStatsManager:
         trip = compute_completed_trip(
             start,
             snapshot,
+            baseline=self.since_charge_baseline,
             capacity_kwh=capacity_kwh,
             tank_litres=tank_litres,
             is_electric=is_electric,
             is_combustion=is_combustion,
         )
+        # Rebase the since-charge baseline to this close's counter values, so the
+        # next trip diffs from here. Only when the counters were available.
+        if snapshot.since_charge_km is not None:
+            self.since_charge_baseline = {
+                "since_charge_km": round(snapshot.since_charge_km, 3),
+                "since_charge_kwh": (
+                    round(snapshot.since_charge_kwh, 3)
+                    if snapshot.since_charge_kwh is not None
+                    else 0.0
+                ),
+            }
         if trip is not None:
             self.last_trip = trip
             self._fire_event(trip)

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -228,5 +228,88 @@ class TestManagerLifecycle(unittest.TestCase):
         self.assertIsNone(m.open_snapshot)  # still cleared so the next drive opens fresh
 
 
+class TestCounterBasedTrip(unittest.TestCase):
+    """Distance/energy from the car's since-charge counters (the preferred path)."""
+
+    def _snap(self, odo, since_km=None, since_kwh=None, soc=None, t="2026-08-20T06:36:00+00:00"):
+        return Snap(ts=t, odometer_km=odo, soc_pct=soc,
+                    since_charge_km=since_km, since_charge_kwh=since_kwh)
+
+    def test_first_trip_since_charge_matches_counters(self):
+        # Reproduces the live report: one drive since charge, baseline at 0.
+        # Odometer only moved 3 km (late/fragmented open) but the counters say 11.
+        start = self._snap(1008.0, since_km=8.0, since_kwh=1.0)  # opened 8 km in
+        end = self._snap(1011.0, since_km=11.0, since_kwh=1.4,
+                         t="2026-08-20T06:51:00+00:00")
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 0.0, "since_charge_kwh": 0.0},
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        # Counter diff (11-0) wins over the 3 km odometer delta.
+        self.assertEqual(trip["distance_km"], 11.0)
+        self.assertEqual(trip["energy_kWh"], 1.4)
+        self.assertAlmostEqual(trip["efficiency_km_per_kWh"], 7.86, places=2)
+        self.assertAlmostEqual(trip["efficiency_mi_per_kWh"], 4.88, places=2)
+
+    def test_second_trip_diffs_from_previous_close(self):
+        start = self._snap(1020.0, since_km=11.0, since_kwh=1.4)
+        end = self._snap(1027.0, since_km=18.0, since_kwh=2.4)
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 11.0, "since_charge_kwh": 1.4},
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 7.0)
+        self.assertAlmostEqual(trip["energy_kWh"], 1.0, places=3)
+
+    def test_charge_reset_since_last_close(self):
+        # Counter went backwards vs baseline => charged since last close.
+        start = self._snap(1030.0, since_km=0.0, since_kwh=0.0)
+        end = self._snap(1035.0, since_km=5.0, since_kwh=0.8)
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 18.0, "since_charge_kwh": 2.4},
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 5.0)  # current value = the trip
+        self.assertAlmostEqual(trip["energy_kWh"], 0.8, places=3)
+
+    def test_falls_back_to_odometer_when_no_counters(self):
+        start = self._snap(2000.0, soc=80.0)  # no since_charge fields
+        end = self._snap(2040.0, soc=70.0)
+        trip = ts.compute_completed_trip(
+            start, end, baseline=None,
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 40.0)  # odometer delta
+        self.assertAlmostEqual(trip["energy_kWh"], 6.4, places=3)  # SOC×capacity
+
+
+class TestNoteSinceCharge(unittest.TestCase):
+    def _mgr(self):
+        from unittest.mock import MagicMock
+        return ts.TripStatsManager(MagicMock(), "e", "V")
+
+    def test_seeds_then_rebases_on_reset(self):
+        m = self._mgr()
+        self.assertTrue(m.note_since_charge(0.0, 0.0))      # first poll seeds baseline
+        # A close sets the baseline to the last trip's end counter (=11).
+        m.since_charge_baseline = {"since_charge_km": 11.0, "since_charge_kwh": 1.4}
+        self.assertFalse(m.note_since_charge(18.0, 2.4))    # climbing, no rebase
+        self.assertTrue(m.note_since_charge(0.0, 0.0))      # dropped -> charge reset
+        self.assertEqual(m.since_charge_baseline["since_charge_km"], 0.0)
+
+    def test_close_rebases_baseline_to_counter(self):
+        m = self._mgr()
+        m.note_since_charge(0.0, 0.0)
+        m.open(Snap(ts="2026-08-20T06:36:00+00:00", odometer_km=1008.0,
+                    since_charge_km=8.0, since_charge_kwh=1.0))
+        trip = m.close(
+            Snap(ts="2026-08-20T06:51:00+00:00", odometer_km=1011.0,
+                 since_charge_km=11.0, since_charge_kwh=1.4),
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertEqual(trip["distance_km"], 11.0)
+        self.assertEqual(m.since_charge_baseline["since_charge_km"], 11.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Reworks the trip distance/energy maths to use the car's own cumulative counters, fixing the wrong values seen on a live MGS6 EV.

## The problem (from live data, one drive since charging)
- `Mileage Since Last Charge` = **6.84 mi (11 km)**, `Power Usage Since Last Charge` = **1.40 kWh** — correct (the car's counters), so with one drive since charge, this *is* the trip.
- `Last Trip Distance` = **1.86 mi (3 km)** ❌, `Last Trip Efficiency` attributes: `energy_kWh` 0.149, `soc_used_pct` 0.2 → efficiency ~20 km/kWh ❌ (implausible).

The odometer delta (3 km) and the since-charge counter (11 km) come from the *same poll*, so they track the same driving — meaning the trip **opened ~8 km late** (a stop mid-journey, or a prior trip that didn't close cleanly). And deriving energy from whole-percent SOC makes short-trip efficiency wildly off.

## Fix
Derive distance and electric energy from the car's own cumulative counters — `mileageSinceLastCharge` / `powerUsageSinceLastCharge` — diffed against a **baseline captured at the previous trip's close** (rebased to ~0 when a charge resets the counter). This is the car's measurement and, crucially, doesn't depend on when the trip's *open* snapshot was taken, so late/fragmented opens no longer skew the numbers. Energy is now measured, not inferred from coarse SOC.

- `TripSnapshot` gains `since_charge_km` / `since_charge_kwh`.
- `compute_completed_trip` prefers counter diffs; falls back to the odometer delta (and SOC×capacity for energy) for non-charging models or a charging-endpoint dropout.
- The manager tracks the baseline, rebases on a charge reset (`note_since_charge` every poll) and after each close; persisted across restarts.
- Fuel (ICE/HEV/PHEV) still uses the fuel-level delta.

On the live numbers this yields **11 km, 1.4 kWh, 4.88 mi/kWh** — matching `Efficiency Since Last Charge`.

## Notes
- A trip is one power-on→power-off, so a journey with a stop counts as two trips (each now measured correctly). README updated to say so.
- Tests: counter-based distance/energy incl. the exact live scenario, second-trip diff, charge-reset, odometer fallback, baseline reset/rebase. Full suite green (155).
- Manifest → `1.2.5-beta6`.
