### PR TITLE
fix(profiles): MGS5 EV battery capacity 64 → 62.1 kWh usable (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ The integration includes built-in profiles for specific MG/SAIC models that corr
 | `EH32` | MG4 Electric | Temperature range and fan speed values confirmed; PTC resistive **Heat** mode supported (#173) |
 | `AH4EM` | MG4 EV URBAN | Mode-select climate scheme (owner-confirmed, #243); this variant has no heat mode — see [Climate Control](#climate-control) |
 | `MIS3E` | MGS6 EV (Long Range / Dual Motor) | Battery capacity 74.3 kWh; inverted temperature index; model year override (API reports 2024, corrected to 2025) |
-| `MZS3E` | MGS5 EV | Mode-select climate scheme mirroring the MGS6 (status code 2 = cool, #277); battery capacity confirmed 64 kWh (EU169A64S); temperature index inherited from the MGS6 as best-effort |
+| `MZS3E` | MGS5 EV | Mode-select climate scheme mirroring the MGS6 (status code 2 = cool, #277); battery capacity 62.1 kWh usable (64 kWh gross pack EU169A64S, #301); temperature index inherited from the MGS6 as best-effort |
 | `EC32` | MG Cyberster | 2-door BEV roadster; no rear doors/windows; unreliable live electric range field (falls back to estimated range) |
 | `IS31P` | MG S9 PHEV (2025) | Climate status/fan speed mappings confirmed by physical testing |
 | `AS33P` | MG HS PHEV (Super Hybrid 2025/2026) | Battery capacity 24.7 kWh; Target SOC and Charging Current Limit not supported by iSmart; electric range uses live SOC-tracking field; energy values corrected for ~3x API over-reporting |

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -371,10 +371,14 @@ VEHICLE_PROFILES = {
         "min_temp": 16,
         "max_temp": 30,
         "temp_offset": 2,
-        # 64 kWh pack (EU169A64S) — nominal/pack capacity per the owner's manual.
-        # Note the convention above is "usable"; owner requested the 64 kWh pack
-        # figure and it matches the "Total Battery Capacity" sensor name.
-        "battery_capacity_kwh": 64.0,
+        # 64 kWh gross pack (EU169A64S), 62.1 kWh usable — a 1.9 kWh (3.0%)
+        # protection buffer, confirmed by MG's spec and multiple EV databases.
+        # The table's convention is usable capacity (it feeds the Last Trip /
+        # efficiency energy maths as well as the capacity sensor), so we use
+        # 62.1 here. Reported by SteveMSJ (#301): the earlier 64.0 was the gross
+        # pack figure. The MGS5 EV ships only as this Long Range / Trophy LR
+        # pack in these markets, so a single override is safe.
+        "battery_capacity_kwh": 62.1,
         "temp_idx_inverted": False,
         "temp_index_map": {
             16: 1, 17: 3, 18: 4, 19: 5, 20: 6, 21: 7, 22: 8, 23: 9, 24: 10,

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -160,6 +160,11 @@ class TestBatteryCapacityOverridesAreSane(unittest.TestCase):
                 self.assertGreater(capacity, 5.0, msg=f"{key} capacity too small")
                 self.assertLess(capacity, 250.0, msg=f"{key} capacity too large")
 
+    def test_mgs5_uses_usable_not_gross_capacity(self):
+        # #301 (SteveMSJ): MGS5 EV Long Range is 64 kWh gross / 62.1 kWh usable.
+        # The table's convention is usable, so it must be 62.1, not 64.0.
+        self.assertEqual(const.VEHICLE_PROFILES["MZS3E"]["battery_capacity_kwh"], 62.1)
+
 
 class TestFuelTankSizes(unittest.TestCase):
     """#301: per-model fuel-tank litres for the combustion (ICE/HEV/PHEV) profiles."""


### PR DESCRIPTION
## Summary
Fixes the MGS5 EV battery capacity reported by **SteveMSJ (#301)**: it showed **64 kWh** but should be **62.1 kWh**.

The MGS5 EV Long Range uses a 64 kWh **gross** pack with a 1.9 kWh (3.0%) protection buffer → **62.1 kWh usable** (confirmed by MG's spec sheet and multiple EV databases; both Long Range and Trophy Long Range share this pack). The `battery_capacity_kwh` table is documented as *usable* capacity and now also feeds the Last Trip / efficiency energy maths, so the earlier `64.0` (gross) was the wrong figure for this purpose.

The MGS5 EV ships only as this pack in the relevant markets, so a single override is safe.

## Changes
- `const.py`: `MZS3E` battery_capacity_kwh `64.0` → `62.1`, with a sourced comment.
- Test pins `MZS3E` to 62.1; README model table updated.
- Full suite green (160).

## Not included — MG4 capacity (also in #301)
Steve's other report (MG4 Trophy LR showing 72.5, should be 61.7) is **not** fixed here, deliberately: the `EH32` MG4 profile spans **three** packs — SE Standard Range 51 kWh (50.8 usable), Long Range/Trophy 64 kWh (61.7 usable), and Extended Range 77 kWh (74.4 usable). Hard-coding 61.7 on the shared `EH32` key would give the wrong value to SR and ER owners. The 72.5 Steve sees is the API's known-bogus `725` placeholder. A correct fix needs a **variant-specific series-substring override** (the table already matches on series substrings), which requires the exact `series` string for each MG4 variant — starting with Steve's Trophy LR.
