### PR TITLE
fix(phev): correct powerUsageSinceLastCharge inflation on HS PHEV (#262, #301)

### DIFF
--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -486,11 +486,13 @@ VEHICLE_PROFILES = {
     "AS33P": {  # MG HS PHEV (2025/2026 Super Hybrid)
         # Series string from API: 'AS33P S'
         # Battery capacity: API reports totalBatteryCapacity=725 (→ 72.5 kWh with
-        # ×0.1 factor), which is incorrect by a factor of ~3.  The HS PHEV has a
-        # 24.7 kWh usable PHEV battery; override here so the sensor shows correctly.
+        # ×0.1 factor), which is inflated by ~3×. The HS PHEV pack is 24.7 kWh
+        # nominal / 23.2 kWh usable; we display the usable figure (the table's
+        # convention, and it feeds the SOC×capacity fallback). The ~1/3 energy
+        # correction below is derived from the nominal 24.7 (24.7/72.5 ≈ 0.3407).
         # lastChargeEndingPower similarly reports 724 (÷10 = 72.4 kWh) — the profile
         # battery_capacity_kwh override covers totalBatteryCapacity; lastChargeEndingPower
-        # is corrected via PHEV_BATTERY_CAPACITY_CORRECTION_FACTOR in the profile.
+        # AND powerUsageSinceLastCharge are corrected via charging_capacity_correction.
         # AC temperature: the app slider runs 16–30 °C (plus LO/HI beyond).
         # Decrypted iSmart traffic (issue #262, Harry's car) confirms a linear
         # wire index of temp − 14: 16 °C → paramId 20 = 2, 23 °C → 9, 29 °C → 15
@@ -511,7 +513,7 @@ VEHICLE_PROFILES = {
         # sends rvcReqType=6 {paramId 19:1, 20:0, 22:1, 255:0} (decoded #262).
         # We expose it as HA's Fan Only HVAC mode for this car.
         "climate_fan_only_airflow": True,
-        "battery_capacity_kwh": 24.7,
+        "battery_capacity_kwh": 23.2,
         # ⚠ MG HS PHEV petrol tank is MARKET-SPLIT (#301): UK/EU official spec is
         # 37 L (MG UK dealer product guide), but the Australian "Super Hybrid" is
         # 55 L (confirmed by multiple AU reviews/long-term tests). Same AS33P

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1310,10 +1310,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     @staticmethod
-    def _extract_since_charge(charging_data):
+    def _extract_since_charge_raw(charging_data):
         """(distance_km, energy_kWh) since last charge from rvsChargeStatus, or
-        (None, None). The car's own cumulative counters — preferred source for
-        trip distance/energy (see trip_stats.compute_completed_trip)."""
+        (None, None), WITHOUT the per-model energy correction. Internal."""
         rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
         if rcs is None:
             return None, None
@@ -1321,6 +1320,20 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         kwh_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
         km = km_raw * DATA_DECIMAL_CORRECTION if km_raw is not None and km_raw >= 0 else None
         kwh = kwh_raw * DATA_DECIMAL_CORRECTION if kwh_raw is not None and kwh_raw >= 0 else None
+        return km, kwh
+
+    def _extract_since_charge(self, charging_data):
+        """(distance_km, energy_kWh) since last charge from rvsChargeStatus, or
+        (None, None). The car's own cumulative counters — preferred source for
+        trip distance/energy (see trip_stats.compute_completed_trip).
+
+        Some PHEVs (e.g. HS PHEV / AS33P) report energy fields inflated by ~3×
+        (the same quirk corrected for totalBatteryCapacity/lastChargeEndingPower),
+        so apply the profile's charging_capacity_correction to the ENERGY only —
+        distance is never inflated — giving real kWh for trip energy/efficiency."""
+        km, kwh = self._extract_since_charge_raw(charging_data)
+        if kwh is not None and self.charging_capacity_correction is not None:
+            kwh = kwh * self.charging_capacity_correction
         return km, kwh
 
     @staticmethod

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2293,11 +2293,15 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
                         return None
                     if raw_value is not None:
                         result = raw_value * self._factor
-                        # lastChargeEndingPower: some models (e.g. HS PHEV) report
-                        # this field inflated by ~3× relative to the true kWh value.
-                        # Apply the profile's charging_capacity_correction factor
-                        # when set so the displayed value matches the real battery.
-                        if self._field == "lastChargeEndingPower":
+                        # lastChargeEndingPower / powerUsageSinceLastCharge: some
+                        # models (e.g. HS PHEV) report these energy fields inflated
+                        # by ~3× relative to the true kWh value. Apply the profile's
+                        # charging_capacity_correction factor when set so the
+                        # displayed value matches the real battery.
+                        if self._field in (
+                            "lastChargeEndingPower",
+                            "powerUsageSinceLastCharge",
+                        ):
                             correction = getattr(
                                 self.coordinator, "charging_capacity_correction", None
                             )
@@ -3220,8 +3224,14 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
         energy_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
         if dist_raw is None or energy_raw is None:
             return None
+        energy = energy_raw * DATA_DECIMAL_CORRECTION
+        # Correct PHEV energy inflation (e.g. HS PHEV) so the efficiency is real
+        # — mirrors the Power Usage Since Last Charge sensor. Distance untouched.
+        correction = getattr(self.coordinator, "charging_capacity_correction", None)
+        if correction is not None:
+            energy = energy * correction
         return compute_since_charge_efficiency(
-            dist_raw * DATA_DECIMAL_CORRECTION, energy_raw * DATA_DECIMAL_CORRECTION
+            dist_raw * DATA_DECIMAL_CORRECTION, energy
         )
 
     @property

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -225,6 +225,18 @@ class TestAS33PClimate(unittest.TestCase):
         self.assertTrue(cool.isdisjoint(fan_only))
         self.assertNotIn(0, cool)  # 0 is "off", never a cooling status
 
+    def test_usable_capacity_and_energy_correction(self):
+        # HS PHEV pack: 24.7 kWh nominal / 23.2 kWh usable — display the usable.
+        self.assertEqual(self.p["battery_capacity_kwh"], 23.2)
+        # The API inflates energy fields (~3x); a correction must be present so
+        # powerUsageSinceLastCharge / lastChargeEndingPower read as real kWh.
+        correction = self.p["charging_capacity_correction"]
+        self.assertIsNotNone(correction)
+        # Sanity-check against the live report (#262/#301): the raw 41.9 kWh
+        # Power Usage Since Last Charge must correct to roughly the real ~14 kWh
+        # battery draw (57.9% of 24.7), not stay ~3x too high.
+        self.assertAlmostEqual(41.9 * correction, 14.0, delta=0.6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes the HS PHEV `Power Usage Since Last Charge` reading (and the efficiency/trip figures built on it), reported via #262/#301.

## Root cause
Harry's HS PHEV showed **41.9 kWh** used since last charge — impossible for a 24.7 kWh pack. The SAIC API reports this car's **energy** fields inflated by ~2.935× — the same quirk that makes `totalBatteryCapacity` read 72.5 instead of 24.7. We already correct `totalBatteryCapacity` (profile override) and `lastChargeEndingPower` (`charging_capacity_correction`), **but not `powerUsageSinceLastCharge`**.

Applying the same correction:

```
41.9 × (24.7 / 72.5) = 14.3 kWh
```

…which exactly matches the real battery draw Harry measured (57.9% of 24.7 kWh = 14.3 kWh). So the value was simply **wrong**, not "cumulative throughput including engine charging" as first suspected — and no caveat is needed, the figure can be made correct.

## Changes
- `coordinator._extract_since_charge`: apply `charging_capacity_correction` to the **energy only** (distance is never inflated) — corrects trip energy & efficiency (#307).
- `sensor.py`: apply the correction to the **Power Usage Since Last Charge** sensor and to **Efficiency Since Last Charge**, mirroring `lastChargeEndingPower`.
- `const.py` (AS33P): display **usable** capacity 23.2 kWh (24.7 nominal); clarify that the ~1/3 correction is derived from the nominal figure and now covers `powerUsageSinceLastCharge` too.

The correction is per-profile, so BEVs and any PHEV without the inflation are unaffected. Tests pin the AS33P usable capacity + correction and verify the live 41.9 kWh lands near the real ~14 kWh. Full suite green (160).

## Follow-up (separate)
A missed-trip issue on the MGS6 (a short morning drive that was never polled while powered, so no trip opened) is **not** part of this PR — tracking separately.
