### PR TITLE
feat(trip-stats): reconstruct missed trips + force-close stuck trips (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ The integration derives per-trip and per-charge efficiency from data it already 
 
 **Last Trip** sensors are populated when a drive ends (the car powers off). Distance and electric energy come from the car's own cumulative counters (`Mileage Since Last Charge` / `Power Usage Since Last Charge`), diffed between one trip and the next — so they match the car's own measurements and don't depend on exactly when the trip was detected. (For non-charging models, distance falls back to the odometer.) A charge between trips is handled automatically (the counters reset). A trip is one power-on to power-off, so a journey with a stop in the middle counts as two trips.
 
+If a drive is never seen live — the car wasn't polled while it was powered (a short trip that fell between polls, or a missed vehicle-start message) — the trip is reconstructed afterwards from the odometer movement once the car is next seen parked. These reconstructed trips carry `retrospective: true` and `timing: approximate` attributes, because the exact start/end times aren't known and several short hops in the same gap may be merged into one. If a trip ever gets stuck "open" (its power-off was missed), it's force-closed automatically so it doesn't block new trips.
+
 The `Last Trip Efficiency` (BEV/PHEV) and `Last Trip Fuel Economy` (ICE/HEV/PHEV) sensors carry the full breakdown of the last drive in their **attributes**: distance, SOC used, energy in kWh, fuel used, duration, and both metric and mi/kWh figures. A `mg_saic_trip_completed` event also fires for each completed trip (with the same fields), so automations and the logbook can keep a full history without any single sensor holding a list.
 
 Notes and limitations:

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -486,11 +486,13 @@ VEHICLE_PROFILES = {
     "AS33P": {  # MG HS PHEV (2025/2026 Super Hybrid)
         # Series string from API: 'AS33P S'
         # Battery capacity: API reports totalBatteryCapacity=725 (→ 72.5 kWh with
-        # ×0.1 factor), which is incorrect by a factor of ~3.  The HS PHEV has a
-        # 24.7 kWh usable PHEV battery; override here so the sensor shows correctly.
+        # ×0.1 factor), which is inflated by ~3×. The HS PHEV pack is 24.7 kWh
+        # nominal / 23.2 kWh usable; we display the usable figure (the table's
+        # convention, and it feeds the SOC×capacity fallback). The ~1/3 energy
+        # correction below is derived from the nominal 24.7 (24.7/72.5 ≈ 0.3407).
         # lastChargeEndingPower similarly reports 724 (÷10 = 72.4 kWh) — the profile
         # battery_capacity_kwh override covers totalBatteryCapacity; lastChargeEndingPower
-        # is corrected via PHEV_BATTERY_CAPACITY_CORRECTION_FACTOR in the profile.
+        # AND powerUsageSinceLastCharge are corrected via charging_capacity_correction.
         # AC temperature: the app slider runs 16–30 °C (plus LO/HI beyond).
         # Decrypted iSmart traffic (issue #262, Harry's car) confirms a linear
         # wire index of temp − 14: 16 °C → paramId 20 = 2, 23 °C → 9, 29 °C → 15
@@ -511,7 +513,7 @@ VEHICLE_PROFILES = {
         # sends rvcReqType=6 {paramId 19:1, 20:0, 22:1, 255:0} (decoded #262).
         # We expose it as HA's Fan Only HVAC mode for this car.
         "climate_fan_only_airflow": True,
-        "battery_capacity_kwh": 24.7,
+        "battery_capacity_kwh": 23.2,
         # ⚠ MG HS PHEV petrol tank is MARKET-SPLIT (#301): UK/EU official spec is
         # 37 L (MG UK dealer product guide), but the Australian "Super Hybrid" is
         # 55 L (confirmed by multiple AU reviews/long-term tests). Same AS33P

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1392,24 +1392,46 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         km, kwh = self._extract_since_charge(charging_data)
         if self.trip_stats.note_since_charge(km, kwh):
             self._schedule_trip_save()
+
+        snap = self._trip_snapshot(basic_status, charging_data)
+        trip_kwargs = dict(
+            capacity_kwh=self.known_battery_capacity_kwh,
+            tank_litres=self.known_fuel_tank_litres,
+            is_electric=self.vehicle_type in ("BEV", "PHEV"),
+            is_combustion=self.vehicle_type in ("ICE", "HEV", "PHEV"),
+        )
+
+        # Safety net: force-close a trip that's been open implausibly long (a
+        # missed power-off), so it stops blocking new trips.
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if self.trip_stats.force_close_if_stale(now_iso, snap, **trip_kwargs) is not None:
+            LOGGER.debug("Stale trip force-closed for VIN %s", self.vin)
+            self._schedule_trip_save()
+
         driving = power_mode in (2, 3)
         open_snap = self.trip_stats.open_snapshot
-        if driving and open_snap is None:
-            snap = self._trip_snapshot(basic_status, charging_data)
-            if snap is not None and self.trip_stats.open(snap):
+        if driving:
+            if open_snap is None and snap is not None and self.trip_stats.open(snap):
                 LOGGER.debug("Trip opened for VIN %s at %s km", self.vin, snap.odometer_km)
                 self._schedule_trip_save()
-        elif not driving and open_snap is not None:
-            snap = self._trip_snapshot(basic_status, charging_data)
-            if snap is not None:
-                trip = self.trip_stats.close(
-                    snap,
-                    capacity_kwh=self.known_battery_capacity_kwh,
-                    tank_litres=self.known_fuel_tank_litres,
-                    is_electric=self.vehicle_type in ("BEV", "PHEV"),
-                    is_combustion=self.vehicle_type in ("ICE", "HEV", "PHEV"),
-                )
-                LOGGER.debug("Trip closed for VIN %s: %s", self.vin, trip)
+            return
+        # Parked (or unknown) — a reading is needed to close or reconstruct.
+        if snap is None:
+            return
+        if open_snap is not None:
+            trip = self.trip_stats.close(snap, **trip_kwargs)
+            LOGGER.debug("Trip closed for VIN %s: %s", self.vin, trip)
+            self._schedule_trip_save()
+        else:
+            # No trip open + parked: reconstruct a drive that was never seen live
+            # (e.g. the car wasn't polled while powered). Advances the parked
+            # baseline either way; persist when a trip lands or we just seeded it.
+            was_seeded = self.trip_stats.last_parked_snapshot is None
+            trip = self.trip_stats.detect_missed_trip(snap, **trip_kwargs)
+            if trip is not None:
+                LOGGER.debug("Missed trip reconstructed for VIN %s: %s", self.vin, trip)
+                self._schedule_trip_save()
+            elif was_seeded:
                 self._schedule_trip_save()
 
     def _schedule_trip_save(self):

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1310,10 +1310,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     @staticmethod
-    def _extract_since_charge(charging_data):
+    def _extract_since_charge_raw(charging_data):
         """(distance_km, energy_kWh) since last charge from rvsChargeStatus, or
-        (None, None). The car's own cumulative counters — preferred source for
-        trip distance/energy (see trip_stats.compute_completed_trip)."""
+        (None, None), WITHOUT the per-model energy correction. Internal."""
         rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
         if rcs is None:
             return None, None
@@ -1321,6 +1320,20 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         kwh_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
         km = km_raw * DATA_DECIMAL_CORRECTION if km_raw is not None and km_raw >= 0 else None
         kwh = kwh_raw * DATA_DECIMAL_CORRECTION if kwh_raw is not None and kwh_raw >= 0 else None
+        return km, kwh
+
+    def _extract_since_charge(self, charging_data):
+        """(distance_km, energy_kWh) since last charge from rvsChargeStatus, or
+        (None, None). The car's own cumulative counters — preferred source for
+        trip distance/energy (see trip_stats.compute_completed_trip).
+
+        Some PHEVs (e.g. HS PHEV / AS33P) report energy fields inflated by ~3×
+        (the same quirk corrected for totalBatteryCapacity/lastChargeEndingPower),
+        so apply the profile's charging_capacity_correction to the ENERGY only —
+        distance is never inflated — giving real kWh for trip energy/efficiency."""
+        km, kwh = self._extract_since_charge_raw(charging_data)
+        if kwh is not None and self.charging_capacity_correction is not None:
+            kwh = kwh * self.charging_capacity_correction
         return km, kwh
 
     @staticmethod

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3104,6 +3104,8 @@ _TRIP_ATTR_KEYS = (
     "refuelled_during_park",
     "start_ts",
     "end_ts",
+    "retrospective",
+    "timing",
 )
 
 

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2293,11 +2293,15 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
                         return None
                     if raw_value is not None:
                         result = raw_value * self._factor
-                        # lastChargeEndingPower: some models (e.g. HS PHEV) report
-                        # this field inflated by ~3× relative to the true kWh value.
-                        # Apply the profile's charging_capacity_correction factor
-                        # when set so the displayed value matches the real battery.
-                        if self._field == "lastChargeEndingPower":
+                        # lastChargeEndingPower / powerUsageSinceLastCharge: some
+                        # models (e.g. HS PHEV) report these energy fields inflated
+                        # by ~3× relative to the true kWh value. Apply the profile's
+                        # charging_capacity_correction factor when set so the
+                        # displayed value matches the real battery.
+                        if self._field in (
+                            "lastChargeEndingPower",
+                            "powerUsageSinceLastCharge",
+                        ):
                             correction = getattr(
                                 self.coordinator, "charging_capacity_correction", None
                             )
@@ -3220,8 +3224,14 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
         energy_raw = getattr(rcs, "powerUsageSinceLastCharge", None)
         if dist_raw is None or energy_raw is None:
             return None
+        energy = energy_raw * DATA_DECIMAL_CORRECTION
+        # Correct PHEV energy inflation (e.g. HS PHEV) so the efficiency is real
+        # — mirrors the Power Usage Since Last Charge sensor. Distance untouched.
+        correction = getattr(self.coordinator, "charging_capacity_correction", None)
+        if correction is not None:
+            energy = energy * correction
         return compute_since_charge_efficiency(
-            dist_raw * DATA_DECIMAL_CORRECTION, energy_raw * DATA_DECIMAL_CORRECTION
+            dist_raw * DATA_DECIMAL_CORRECTION, energy
         )
 
     @property

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -46,6 +46,15 @@ from typing import Any
 # or a garbage reading. A genuine single drive won't exceed this.
 MAX_PLAUSIBLE_TRIP_KM = 2000.0
 
+# Minimum odometer movement (km) for a retrospective (never-seen-live) trip to
+# be recorded, so odometer rounding / parking shuffles aren't logged as trips.
+MIN_RETRO_TRIP_KM = 1.0
+
+# A trip open longer than this (seconds) is assumed stuck — the power-off poll
+# was missed — and is force-closed so it stops blocking new trips. Set well
+# beyond any plausible single drive.
+MAX_OPEN_TRIP_SECONDS = 24 * 3600
+
 # Efficiency ratio helpers.
 KM_PER_MILE = 1.609344
 
@@ -128,6 +137,7 @@ def compute_completed_trip(
     tank_litres: float | None,
     is_electric: bool,
     is_combustion: bool,
+    retrospective: bool = False,
 ) -> dict[str, Any] | None:
     """Compute a completed-trip dict for the drive ending at ``end``.
 
@@ -140,6 +150,14 @@ def compute_completed_trip(
     for energy) when the counters aren't available (e.g. non-charging models, or
     a charging-endpoint dropout).
 
+    ``retrospective=True`` marks a trip reconstructed after the fact — one that
+    was never observed live (the car wasn't polled while powered) or an open
+    trip force-closed as stale. Such trips span an unknown window that may
+    include a charge, so the since-charge counters can't be trusted: distance
+    comes from the odometer and energy from the SOC change only. The trip is
+    flagged ``retrospective: True`` / ``timing: approximate`` so it's
+    distinguishable, and its timestamps bound the gap rather than the drive.
+
     Returns ``None`` when no plausible distance can be established. Individual
     electric/fuel figures are ``None`` when their inputs are missing.
     """
@@ -150,7 +168,9 @@ def compute_completed_trip(
     base_kwh = baseline.get("since_charge_kwh") if baseline else None
 
     # ── Distance: prefer the since-charge counter, else the odometer delta ────
-    distance_km = _counter_delta(end.since_charge_km, base_km)
+    # Retrospective trips always use the odometer (the counter may have reset in
+    # the unobserved gap).
+    distance_km = None if retrospective else _counter_delta(end.since_charge_km, base_km)
     if distance_km is None:
         distance_km = round(end.odometer_km - start.odometer_km, 2)
     if distance_km <= 0 or distance_km > MAX_PLAUSIBLE_TRIP_KM:
@@ -182,9 +202,12 @@ def compute_completed_trip(
 
     # ── Electric energy (BEV/PHEV) ───────────────────────────────────────────
     if is_electric:
-        energy = _counter_delta(end.since_charge_kwh, base_kwh)
+        # Retrospective trips skip the counter (it may have reset in the gap) and
+        # use the SOC change only.
+        energy = None if retrospective else _counter_delta(end.since_charge_kwh, base_kwh)
         if energy is None and start.soc_pct is not None and end.soc_pct is not None:
-            # Fallback: derive from SOC change (coarse; only when no counter).
+            # Derive from SOC change (coarse; the only source for retrospective
+            # trips, and the fallback when no counter is available).
             soc_used = round(start.soc_pct - end.soc_pct, 1)
             if soc_used < 0:
                 trip["charged_during_park"] = True
@@ -217,6 +240,13 @@ def compute_completed_trip(
                         # mpg here for imperial users (both gallon definitions).
                         trip["fuel_economy_mpg_uk"] = round(282.481 / l_per_100km, 1)
                         trip["fuel_economy_mpg_us"] = round(235.215 / l_per_100km, 1)
+
+    if retrospective:
+        # Reconstructed after the fact: distance is sound but the drive happened
+        # somewhere in the gap, so timestamps bound the gap (duration overstated)
+        # and multiple short hops may be merged into one.
+        trip["retrospective"] = True
+        trip["timing"] = "approximate"
 
     return trip
 
@@ -278,6 +308,10 @@ class TripStatsManager:
         # a charge resets the counter). Distance/energy for the next trip diff
         # against this — see note_since_charge / close.
         self.since_charge_baseline: dict[str, Any] | None = None
+        # The most recent reading taken while parked with no trip open. Used to
+        # reconstruct trips that were never seen live (the car wasn't polled
+        # while powered) — see detect_missed_trip.
+        self.last_parked_snapshot: TripSnapshot | None = None
 
     async def async_load(self) -> None:
         from homeassistant.helpers.storage import Store
@@ -289,6 +323,9 @@ class TripStatsManager:
         self.open_snapshot = TripSnapshot.from_dict(data.get("open_snapshot"))
         self.last_trip = data.get("last_trip")
         self.since_charge_baseline = data.get("since_charge_baseline")
+        self.last_parked_snapshot = TripSnapshot.from_dict(
+            data.get("last_parked_snapshot")
+        )
 
     async def async_save(self) -> None:
         """Persist current open/last-trip state and the since-charge baseline."""
@@ -301,6 +338,11 @@ class TripStatsManager:
                 ),
                 "last_trip": self.last_trip,
                 "since_charge_baseline": self.since_charge_baseline,
+                "last_parked_snapshot": (
+                    self.last_parked_snapshot.to_dict()
+                    if self.last_parked_snapshot
+                    else None
+                ),
             }
         )
 
@@ -368,21 +410,105 @@ class TripStatsManager:
             is_electric=is_electric,
             is_combustion=is_combustion,
         )
-        # Rebase the since-charge baseline to this close's counter values, so the
-        # next trip diffs from here. Only when the counters were available.
-        if snapshot.since_charge_km is not None:
+        return self._finalise(trip, snapshot)
+
+    def _finalise(
+        self, trip: dict[str, Any] | None, end: TripSnapshot
+    ) -> dict[str, Any] | None:
+        """Common tail for close / detect_missed_trip / force_close_if_stale:
+        rebase the since-charge baseline to ``end``, mark ``end`` as the latest
+        parked reading, store & fire the trip if one was produced.
+        """
+        if end.since_charge_km is not None:
             self.since_charge_baseline = {
-                "since_charge_km": round(snapshot.since_charge_km, 3),
+                "since_charge_km": round(end.since_charge_km, 3),
                 "since_charge_kwh": (
-                    round(snapshot.since_charge_kwh, 3)
-                    if snapshot.since_charge_kwh is not None
+                    round(end.since_charge_kwh, 3)
+                    if end.since_charge_kwh is not None
                     else 0.0
                 ),
             }
+        self.last_parked_snapshot = end
         if trip is not None:
             self.last_trip = trip
             self._fire_event(trip)
         return trip
+
+    def detect_missed_trip(
+        self,
+        snapshot: TripSnapshot,
+        *,
+        capacity_kwh: float | None,
+        tank_litres: float | None,
+        is_electric: bool,
+        is_combustion: bool,
+    ) -> dict[str, Any] | None:
+        """Reconstruct a trip that was never seen live.
+
+        Called on a parked poll when no trip is open. If the odometer has
+        advanced since the last parked reading, a drive happened between polls
+        (the car wasn't polled while powered). Records it as a retrospective
+        trip — odometer distance, SOC-based energy, approximate timestamps — and
+        advances the parked baseline. Returns the trip, or None when there was
+        no baseline yet or no meaningful movement.
+        """
+        start = self.last_parked_snapshot
+        if (
+            start is None
+            or snapshot.odometer_km - start.odometer_km < MIN_RETRO_TRIP_KM
+        ):
+            # Nothing to reconstruct — just advance the parked baseline.
+            self.last_parked_snapshot = snapshot
+            return None
+        trip = compute_completed_trip(
+            start,
+            snapshot,
+            baseline=None,  # counters can't be trusted across the unseen gap
+            capacity_kwh=capacity_kwh,
+            tank_litres=tank_litres,
+            is_electric=is_electric,
+            is_combustion=is_combustion,
+            retrospective=True,
+        )
+        return self._finalise(trip, snapshot)
+
+    def force_close_if_stale(
+        self,
+        now_iso: str,
+        snapshot: TripSnapshot | None,
+        *,
+        capacity_kwh: float | None,
+        tank_litres: float | None,
+        is_electric: bool,
+        is_combustion: bool,
+    ) -> dict[str, Any] | None:
+        """Force-close a trip that has been open implausibly long.
+
+        If the power-off poll was missed (or the car reports 'on' indefinitely),
+        a trip can stay open forever and block all new trips. When the open trip
+        is older than MAX_OPEN_TRIP_SECONDS, close it as a retrospective trip
+        against the current reading (or abandon it, clearing state, if we have no
+        reading). Returns the trip, or None if nothing was stale.
+        """
+        if self.open_snapshot is None:
+            return None
+        age = _duration_seconds(self.open_snapshot.ts, now_iso)
+        if age is None or age < MAX_OPEN_TRIP_SECONDS:
+            return None
+        start = self.open_snapshot
+        self.open_snapshot = None
+        end = snapshot if snapshot is not None else start
+        trip = compute_completed_trip(
+            start,
+            end,
+            baseline=None,
+            capacity_kwh=capacity_kwh,
+            tank_litres=tank_litres,
+            is_electric=is_electric,
+            is_combustion=is_combustion,
+            retrospective=True,
+        )
+        return self._finalise(trip, end)
 
     def _fire_event(self, trip: dict[str, Any]) -> None:
         try:

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -311,5 +311,98 @@ class TestNoteSinceCharge(unittest.TestCase):
         self.assertEqual(m.since_charge_baseline["since_charge_km"], 11.0)
 
 
+class TestRetrospectiveTrip(unittest.TestCase):
+    def _mgr(self):
+        from unittest.mock import MagicMock
+        return ts.TripStatsManager(MagicMock(), "e", "V")
+
+    _kw = dict(capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False)
+
+    def test_first_parked_reading_only_seeds_no_trip(self):
+        m = self._mgr()
+        trip = m.detect_missed_trip(
+            Snap(ts="2026-08-21T07:00:00+00:00", odometer_km=2000.0, soc_pct=80.0),
+            **self._kw)
+        self.assertIsNone(trip)  # nothing to compare against yet
+        self.assertIsNotNone(m.last_parked_snapshot)
+
+    def test_odometer_jump_reconstructs_trip(self):
+        m = self._mgr()
+        # Parked at 06:00, then observed parked again at 10:00, 12 km further on:
+        # a drive happened in the gap that was never seen live.
+        m.detect_missed_trip(
+            Snap(ts="2026-08-21T06:00:00+00:00", odometer_km=2000.0, soc_pct=80.0),
+            **self._kw)
+        trip = m.detect_missed_trip(
+            Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2012.0, soc_pct=76.0),
+            **self._kw)
+        self.assertIsNotNone(trip)
+        self.assertEqual(trip["distance_km"], 12.0)          # odometer delta
+        self.assertTrue(trip["retrospective"])
+        self.assertEqual(trip["timing"], "approximate")
+        # Energy from SOC change (4% of 64 kWh), not a counter.
+        self.assertAlmostEqual(trip["energy_kWh"], 2.56, places=2)
+
+    def test_no_movement_advances_baseline_without_trip(self):
+        m = self._mgr()
+        m.detect_missed_trip(
+            Snap(ts="2026-08-21T06:00:00+00:00", odometer_km=2000.0), **self._kw)
+        trip = m.detect_missed_trip(
+            Snap(ts="2026-08-21T06:30:00+00:00", odometer_km=2000.0), **self._kw)
+        self.assertIsNone(trip)  # sub-threshold, just a parked poll
+
+    def test_charge_in_gap_gives_distance_but_no_efficiency(self):
+        m = self._mgr()
+        m.detect_missed_trip(
+            Snap(ts="2026-08-21T06:00:00+00:00", odometer_km=2000.0, soc_pct=40.0),
+            **self._kw)
+        # SOC rose (a charge happened somewhere in the gap) -> no electric figure.
+        trip = m.detect_missed_trip(
+            Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2015.0, soc_pct=90.0),
+            **self._kw)
+        self.assertEqual(trip["distance_km"], 15.0)
+        self.assertTrue(trip["charged_during_park"])
+        self.assertIsNone(trip["efficiency_km_per_kWh"])
+
+
+class TestForceCloseStale(unittest.TestCase):
+    def _mgr(self):
+        from unittest.mock import MagicMock
+        return ts.TripStatsManager(MagicMock(), "e", "V")
+
+    _kw = dict(capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False)
+
+    def test_recent_open_is_not_closed(self):
+        m = self._mgr()
+        m.open(Snap(ts="2026-08-21T09:00:00+00:00", odometer_km=2000.0))
+        # Only 1 hour later — well under the 24h backstop.
+        trip = m.force_close_if_stale(
+            "2026-08-21T10:00:00+00:00",
+            Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2005.0), **self._kw)
+        self.assertIsNone(trip)
+        self.assertIsNotNone(m.open_snapshot)  # still open
+
+    def test_stale_open_is_force_closed(self):
+        m = self._mgr()
+        m.open(Snap(ts="2026-08-20T06:00:00+00:00", odometer_km=2000.0, soc_pct=80.0))
+        # ~28 hours later, parked, 30 km further on.
+        trip = m.force_close_if_stale(
+            "2026-08-21T10:00:00+00:00",
+            Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2030.0, soc_pct=70.0),
+            **self._kw)
+        self.assertIsNotNone(trip)
+        self.assertEqual(trip["distance_km"], 30.0)
+        self.assertTrue(trip["retrospective"])
+        self.assertIsNone(m.open_snapshot)  # unblocked
+
+    def test_stale_open_without_reading_is_abandoned(self):
+        m = self._mgr()
+        m.open(Snap(ts="2026-08-20T06:00:00+00:00", odometer_km=2000.0))
+        # No current reading (car unreachable) — clear the stuck trip, record none.
+        trip = m.force_close_if_stale("2026-08-21T10:00:00+00:00", None, **self._kw)
+        self.assertIsNone(trip)              # 0 distance -> no trip
+        self.assertIsNone(m.open_snapshot)   # but the block is cleared
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -225,6 +225,18 @@ class TestAS33PClimate(unittest.TestCase):
         self.assertTrue(cool.isdisjoint(fan_only))
         self.assertNotIn(0, cool)  # 0 is "off", never a cooling status
 
+    def test_usable_capacity_and_energy_correction(self):
+        # HS PHEV pack: 24.7 kWh nominal / 23.2 kWh usable — display the usable.
+        self.assertEqual(self.p["battery_capacity_kwh"], 23.2)
+        # The API inflates energy fields (~3x); a correction must be present so
+        # powerUsageSinceLastCharge / lastChargeEndingPower read as real kWh.
+        correction = self.p["charging_capacity_correction"]
+        self.assertIsNotNone(correction)
+        # Sanity-check against the live report (#262/#301): the raw 41.9 kWh
+        # Power Usage Since Last Charge must correct to roughly the real ~14 kWh
+        # battery draw (57.9% of 24.7), not stay ~3x too high.
+        self.assertAlmostEqual(41.9 * correction, 14.0, delta=0.6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Fixes the missed-trip problem (a 07:15 drive that never registered) by adding two safety nets alongside the live open/close detection.

## The gap
A trip only *opened* when a poll caught the car powered (`power_mode` in 2/3). So a drive that was never polled while powered — a short trip that fell between polls, or a missed vehicle-start message — was invisible. And a trip whose power-off poll was missed could stay open forever, blocking all new trips.

## Fix
**Retrospective detection.** On a parked poll with no trip open, if the odometer has advanced since the last parked reading, a drive happened in the gap → reconstruct it:
- distance from the **odometer**;
- energy from the **SOC change** (the since-charge counters can't be trusted across an unseen gap that may include a charge);
- timestamps bound the gap.

Flagged `retrospective: true` / `timing: approximate` so they're distinguishable (duration is overstated, and several short hops in one gap merge into one). A charge in the gap gives distance (+ fuel) but leaves efficiency Unknown. Sub-1 km movement is ignored as noise.

**Stale force-close.** A trip open longer than 24 h is force-closed against the current reading (or abandoned if the car is unreachable), so a stuck-open trip can't block new ones.

## Notes
- Live detection stays primary (accurate start/end times, one trip per power-cycle); these only catch what it misses.
- `compute_completed_trip` gains a `retrospective=` mode; the manager persists `last_parked_snapshot`; the Last Trip sensors expose the two new attributes.
- 167 tests green (added retrospective + stale-close coverage). README updated.
- This does **not** poll the car during an unobserved drive — it reconstructs after the fact, so a retrospective trip has correct distance but approximate timing and no live efficiency unless SOC covers it.
