### PR TITLE
feat(options): user-configurable usable battery capacity override (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Last Trip Distance *(distance driven on the last completed drive)*
 - Last Trip Efficiency *(BEV/PHEV; switchable km/kWh · mi/kWh · kWh/100km, full breakdown in attributes)*
 - Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
-- Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value)*
+- Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value, and can be overridden per vehicle — see [Battery capacity override](#battery-capacity-override))*
 - Battery Heating Status *(if equipped)*
 - Reachability *(is the car awake / likely asleep / unreachable — see [Deep sleep & holiday mode](#deep-sleep--holiday-mode))*
 - Data Freshness *(diagnostic: whether the last poll returned `live`, `cached` or `failed` data — see [Data Freshness sensor](#data-freshness-sensor))*
@@ -507,6 +507,13 @@ Under the integration's **Configure** menu:
  
 - **Holiday mode idle interval (hours)** — how slowly to poll while holiday mode is on (default 12)
 - **Data staleness threshold (hours)** — how long without reported activity before the Reachability sensor reads `likely_asleep` (default 12)
+
+### Battery capacity override
+
+Some MG models share one series code across several battery sizes (the MG4, for example, ships with 51, 64, and 77 kWh packs), and the API's reported capacity is unreliable on a few cars — so the value we use isn't always right for your exact variant.
+
+The **Usable battery capacity override (kWh)** option (under **Configure**) lets you set your car's usable capacity yourself. When set, it takes priority over both our built-in per-model value and the API-reported value, and it becomes the figure used everywhere capacity matters: the **Total Battery Capacity** sensor and the electric energy/efficiency calculations (including Last Trip figures on models that fall back to a battery-percentage estimate). Enter the **usable** capacity for your variant; leave it blank to go back to the automatic value.
+
 ## 📋 Entity States Reference
  
 This section lists every possible state for every status and control entity, so you know exactly what to expect when coding dashboards or automations. Home Assistant binary sensors always report the underlying state as **`on`/`off`** — never as descriptive text like "Locked"/"Unlocked" or "Open"/"Closed" — the description below tells you what `on` and `off` actually *mean* for each one. The friendly text ("Open", "Locked", etc.) is only shown in the Lovelace UI because of the entity's device class; the state itself, e.g. as read via `states('binary_sensor...')` in a template, is always `on` or `off`.

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_ABRP_USER_TOKEN,
     CONF_HOLIDAY_UPDATE_INTERVAL,
     CONF_STALE_DATA_THRESHOLD,
+    CONF_BATTERY_CAPACITY_OVERRIDE,
     DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
     DEFAULT_STALE_DATA_THRESHOLD_HOURS,
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
@@ -611,6 +612,19 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                         self.config_entry.data.get("has_window_control", False),
                     ),
                 ): bool,
+                # Usable battery capacity override (kWh). Takes priority over our
+                # per-model value and the API's reported capacity, and feeds the
+                # Total Battery Capacity sensor and the efficiency/trip energy
+                # calculations. Uses suggested_value (not default) and accepts ""
+                # so it can be cleared to fall back to the automatic value.
+                vol.Optional(
+                    CONF_BATTERY_CAPACITY_OVERRIDE,
+                    description={
+                        "suggested_value": self.options.get(
+                            CONF_BATTERY_CAPACITY_OVERRIDE, ""
+                        )
+                    },
+                ): vol.Any("", vol.All(vol.Coerce(float), vol.Range(min=1, max=250))),
                 # A Better Route Planner (ABRP) live-data push. Both the user
                 # token and the API key are user-supplied and required to enable
                 # ABRP for this vehicle; clear both to disable it.

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -836,6 +836,22 @@ DATA_FRESHNESS_FAILED = "failed"
 # Configurable; default sits comfortably inside the observed ~1-day sleep onset.
 DEFAULT_STALE_DATA_THRESHOLD_HOURS = 12
 CONF_STALE_DATA_THRESHOLD = "stale_data_threshold_hours"
+# User-supplied usable battery capacity (kWh). Overrides both our per-model
+# profile value and the API-reported totalBatteryCapacity. Empty/0 = no override.
+CONF_BATTERY_CAPACITY_OVERRIDE = "battery_capacity_override_kwh"
+
+
+def parse_capacity_override(raw):
+    """Parse a user battery-capacity override option into kWh, or None.
+
+    Blank (""/None), non-numeric, or non-positive all mean 'no override' — fall
+    through to our per-model value, then the API value.
+    """
+    try:
+        value = float(raw) if raw not in (None, "") else 0.0
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
 # Remote-command return code that means "can't reach the car right now".
 SAIC_RETURN_CODE_UNREACHABLE = 4
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -33,6 +33,8 @@ from .const import (
     DEFAULT_AC_LONG_INTERVAL,
     CONF_HOLIDAY_UPDATE_INTERVAL,
     CONF_STALE_DATA_THRESHOLD,
+    CONF_BATTERY_CAPACITY_OVERRIDE,
+    parse_capacity_override,
     DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
     DEFAULT_STALE_DATA_THRESHOLD_HOURS,
     REMOTE_CLIMATE_STATUS_DEFROST,
@@ -382,6 +384,14 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # Vehicle capabilities
         self.has_sunroof = config_entry.options.get(
             "has_sunroof", config_entry.data.get("has_sunroof", False)
+        )
+        # User-supplied usable battery capacity (kWh). Highest-priority source
+        # for the capacity used by the Total Battery Capacity sensor and the
+        # SOC×capacity trip-energy fallback: user override > our profile override
+        # > API value. None/0/blank means "no override". Applied where
+        # known_battery_capacity_kwh is resolved once the series is known.
+        self.battery_capacity_override = parse_capacity_override(
+            config_entry.options.get(CONF_BATTERY_CAPACITY_OVERRIDE, None)
         )
         self.has_heated_seats = config_entry.options.get(
             "has_heated_seats", config_entry.data.get("has_heated_seats", False)
@@ -841,6 +851,10 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self.max_temp = profile["max_temp"]
             self.temp_offset = profile["temp_offset"]
             self.known_battery_capacity_kwh = profile["battery_capacity_kwh"]
+            # Precedence: user override > our profile override > API value.
+            # Applied here so every downstream capacity consumer picks it up.
+            if self.battery_capacity_override is not None:
+                self.known_battery_capacity_kwh = self.battery_capacity_override
             self.known_fuel_tank_litres = profile.get("fuel_tank_litres")
             self.climate_status_cool = profile.get("climate_status_cool", {3})
             self.climate_status_fan_only = profile.get("climate_status_fan_only", {2})

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -392,6 +392,7 @@
           "charging_current_long_interval": "Charging Current Long Interval (in minutes)",
           "has_steering_wheel_heat": "Has Steering Wheel Heat",
           "has_window_control": "Has Window Control (Open/Close/Ventilate)",
+          "battery_capacity_override_kwh": "Usable battery capacity override (kWh)",
           "enable_shutdown_refresh_sequence": "Enable Post-Shutdown Refresh Sequence",
           "abrp_user_token": "ABRP user token",
           "abrp_api_key": "ABRP API key"
@@ -399,6 +400,7 @@
         "description": "Define additional settings for MG/SAIC Integration",
         "title": "MG/SAIC Options",
         "data_description": {
+          "battery_capacity_override_kwh": "Your car's usable battery capacity in kWh. Overrides the built-in value used for the Total Battery Capacity sensor and the efficiency/trip energy calculations — set this if your model's capacity is reported incorrectly. Leave blank to use the automatic value.",
           "abrp_user_token": "Paste the user token from the ABRP app (Settings → your car → Live Data → Generic) to send this vehicle's data to A Better Route Planner. You also need your own API key (below) — both are required. Leave both blank to disable. See {abrp_doc_url}.",
           "abrp_api_key": "Enter your own Iternio API key, created in the Iternio developer portal — see {abrp_doc_url}. Required together with the user token to enable ABRP."
         }

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -391,6 +391,7 @@
           "charging_current_long_interval": "Intervalo Largo de Corriente de Carga (en minutos)",
           "has_steering_wheel_heat": "Tiene calefacción en el volante",
           "has_window_control": "Control de ventanas (abrir/cerrar/ventilar)",
+          "battery_capacity_override_kwh": "Anulación de la capacidad útil de la batería (kWh)",
           "enable_shutdown_refresh_sequence": "Habilitar secuencia de actualización tras apagado",
           "abrp_user_token": "Token de usuario de ABRP",
           "abrp_api_key": "Clave API de ABRP"
@@ -398,6 +399,7 @@
         "description": "Define ajustes adicionales para la Integración MG/SAIC",
         "title": "Opciones de MG/SAIC",
         "data_description": {
+          "battery_capacity_override_kwh": "Capacidad útil de la batería de tu coche en kWh. Anula el valor interno usado para el sensor de capacidad total de la batería y para los cálculos de eficiencia y energía de los viajes; úsalo si la capacidad de tu modelo se indica de forma incorrecta. Déjalo en blanco para usar el valor automático.",
           "abrp_user_token": "Pega el token de usuario de la app ABRP (Ajustes → tu coche → Live Data → Generic) para enviar los datos de este vehículo a A Better Route Planner. También necesitas tu propia clave API (abajo); ambas son obligatorias. Deja ambas en blanco para desactivarlo. Consulta {abrp_doc_url}.",
           "abrp_api_key": "Introduce tu propia clave API de Iternio, creada en el portal de desarrolladores de Iternio: consulta {abrp_doc_url}. Obligatoria junto con el token de usuario para activar ABRP."
         }

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -392,6 +392,7 @@
           "charging_current_long_interval": "Intervalle long de l'intensité de charge (en minutes)",
           "has_steering_wheel_heat": "Possède le volant chauffant",
           "has_window_control": "Possède le contrôle des vitres (Ouvrir/Fermer/Aérer)",
+          "battery_capacity_override_kwh": "Remplacement de la capacité utile de la batterie (kWh)",
           "enable_shutdown_refresh_sequence": "Activer la séquence de rafraîchissement post-arrêt",
           "abrp_user_token": "Jeton utilisateur ABRP",
           "abrp_api_key": "Clé API ABRP"
@@ -399,6 +400,7 @@
         "description": "Définir des paramètres supplémentaires pour l'intégration MG/SAIC",
         "title": "Options MG/SAIC",
         "data_description": {
+          "battery_capacity_override_kwh": "Capacité utile de la batterie de votre voiture en kWh. Remplace la valeur interne utilisée pour le capteur de capacité totale de la batterie et pour les calculs d'efficacité et d'énergie des trajets ; utilisez-la si la capacité de votre modèle est indiquée de façon incorrecte. Laissez vide pour utiliser la valeur automatique.",
           "abrp_user_token": "Collez le jeton utilisateur de l'application ABRP (Paramètres → votre voiture → Live Data → Generic) pour envoyer les données de ce véhicule à A Better Route Planner. Vous avez aussi besoin de votre propre clé API (ci-dessous) ; les deux sont requises. Laissez les deux vides pour désactiver. Voir {abrp_doc_url}.",
           "abrp_api_key": "Saisissez votre propre clé API Iternio, créée dans le portail développeur Iternio — voir {abrp_doc_url}. Requise avec le jeton utilisateur pour activer ABRP."
         }

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -392,6 +392,7 @@
           "charging_current_long_interval": "Intervalo Longo Corrente de Carregamento (em minutos)",
           "has_steering_wheel_heat": "Tem aquecimento no volante",
           "has_window_control": "Controlo das janelas (abrir/fechar/ventilar)",
+          "battery_capacity_override_kwh": "Substituição da capacidade útil da bateria (kWh)",
           "enable_shutdown_refresh_sequence": "Ativar sequência de atualização pós-desligamento",
           "abrp_user_token": "Token de utilizador ABRP",
           "abrp_api_key": "Chave de API do ABRP"
@@ -399,6 +400,7 @@
         "description": "Definir configurações adicionais para Integração MG/SAIC",
         "title": "Opções MG/SAIC",
         "data_description": {
+          "battery_capacity_override_kwh": "Capacidade útil da bateria do seu carro em kWh. Substitui o valor interno usado no sensor de capacidade total da bateria e nos cálculos de eficiência e energia das viagens — use se a capacidade do seu modelo for indicada incorretamente. Deixe em branco para usar o valor automático.",
           "abrp_user_token": "Cole o token de utilizador da aplicação ABRP (Definições → o seu carro → Live Data → Generic) para enviar os dados deste veículo para o A Better Route Planner. Também precisa da sua própria chave de API (abaixo); ambas são obrigatórias. Deixe ambas em branco para desativar. Consulte {abrp_doc_url}.",
           "abrp_api_key": "Introduza a sua própria chave de API da Iternio, criada no portal de programadores da Iternio — consulte {abrp_doc_url}. Obrigatória juntamente com o token de utilizador para ativar o ABRP."
         }

--- a/tests/test_vehicle_profiles.py
+++ b/tests/test_vehicle_profiles.py
@@ -226,5 +226,40 @@ class TestAS33PClimate(unittest.TestCase):
         self.assertNotIn(0, cool)  # 0 is "off", never a cooling status
 
 
+class TestBatteryCapacityOverride(unittest.TestCase):
+    """User-supplied usable-capacity override (options flow)."""
+
+    def test_parse_blank_and_none_mean_no_override(self):
+        self.assertIsNone(const.parse_capacity_override(None))
+        self.assertIsNone(const.parse_capacity_override(""))
+
+    def test_parse_non_positive_means_no_override(self):
+        self.assertIsNone(const.parse_capacity_override(0))
+        self.assertIsNone(const.parse_capacity_override("0"))
+        self.assertIsNone(const.parse_capacity_override(-5))
+
+    def test_parse_non_numeric_means_no_override(self):
+        self.assertIsNone(const.parse_capacity_override("abc"))
+
+    def test_parse_valid_values(self):
+        self.assertEqual(const.parse_capacity_override(61.7), 61.7)
+        self.assertEqual(const.parse_capacity_override("62.1"), 62.1)
+
+    def test_precedence_user_over_profile_over_api(self):
+        # Mirror the coordinator's resolution: start from the profile value,
+        # then let a user override win. API value only used when both are absent.
+        def resolve(profile_val, user_override, api_val):
+            known = profile_val  # profile (may be None -> API used downstream)
+            override = const.parse_capacity_override(user_override)
+            if override is not None:
+                known = override
+            return known if known is not None else api_val
+
+        self.assertEqual(resolve(62.1, "61.7", 72.5), 61.7)   # user wins
+        self.assertEqual(resolve(62.1, "", 72.5), 62.1)       # profile wins
+        self.assertEqual(resolve(None, "", 72.5), 72.5)       # API fallback
+        self.assertEqual(resolve(None, "61.7", 72.5), 61.7)   # user over API
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Adds a per-vehicle **Usable battery capacity override (kWh)** option, so users can fix the capacity when our automatic value is wrong for their variant.

Motivated by #301: some models share one series code across several battery sizes (the MG4 ships with 51 / 64 / 77 kWh packs), and the API-reported capacity is unreliable on a few cars — so a single built-in value can't be right for everyone.

## Precedence
**User override → our per-model profile value → API value.** Resolved at the single point where `known_battery_capacity_kwh` is set, so every consumer picks it up and the API value is never used once an override is present. The override feeds:
- the **Total Battery Capacity** sensor, and
- the electric energy / efficiency calculations (including Last Trip figures on models that fall back to a battery-percentage estimate).

Blank / `0` / non-numeric clears it and returns to the automatic value.

## Changes
- `const.py`: `CONF_BATTERY_CAPACITY_OVERRIDE` + a small `parse_capacity_override()` helper.
- `coordinator`: read the option and apply it over the profile value (covers the profiled, unprofiled, and default-profile branches).
- `config_flow`: clearable numeric field — `vol.Any("", vol.All(vol.Coerce(float), vol.Range(min=1, max=250)))`, using `suggested_value` so it can be emptied.
- `translations`: en / es / fr / pt label + `data_description`.
- `README`: new **Battery capacity override** section + sensor note.

Tests cover the parse helper (blank / 0 / negative / non-numeric / valid) and the precedence resolution. Full suite green (164).

## Related
This is the general-purpose escape hatch for the **MG4 capacity** report in #301 that can't be hard-coded (three packs under one series code). A user with any affected variant can now set the correct usable figure themselves.
