### PR TITLE
fix(config-flow): options page 500 — battery-capacity override schema not serializable

### DIFF
--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -557,8 +557,25 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Manage the options."""
         errors = {}
+        def _normalise_capacity(user_input, errors):
+            """Blank clears the override; otherwise store a validated float."""
+            raw = user_input.get(CONF_BATTERY_CAPACITY_OVERRIDE, "")
+            if raw in (None, ""):
+                user_input.pop(CONF_BATTERY_CAPACITY_OVERRIDE, None)
+                return
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                errors[CONF_BATTERY_CAPACITY_OVERRIDE] = "capacity_invalid"
+                return
+            if not 1 <= value <= 250:
+                errors[CONF_BATTERY_CAPACITY_OVERRIDE] = "capacity_out_of_range"
+                return
+            user_input[CONF_BATTERY_CAPACITY_OVERRIDE] = value
+
         if user_input is not None:
             errors = await self._validate_abrp(user_input)
+            _normalise_capacity(user_input, errors)
             if not errors:
                 return self.async_create_entry(title="", data=user_input)
 
@@ -615,8 +632,9 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                 # Usable battery capacity override (kWh). Takes priority over our
                 # per-model value and the API's reported capacity, and feeds the
                 # Total Battery Capacity sensor and the efficiency/trip energy
-                # calculations. Uses suggested_value (not default) and accepts ""
-                # so it can be cleared to fall back to the automatic value.
+                # calculations. A plain text field (so it serialises and can be
+                # cleared); validated/normalised to a float on submit. Uses
+                # suggested_value (not default) so blank clears the override.
                 vol.Optional(
                     CONF_BATTERY_CAPACITY_OVERRIDE,
                     description={
@@ -624,7 +642,7 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_BATTERY_CAPACITY_OVERRIDE, ""
                         )
                     },
-                ): vol.Any("", vol.All(vol.Coerce(float), vol.Range(min=1, max=250))),
+                ): str,
                 # A Better Route Planner (ABRP) live-data push. Both the user
                 # token and the API key are user-supplied and required to enable
                 # ABRP for this vehicle; clear both to disable it.

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -410,7 +410,9 @@
       "abrp_invalid_auth": "ABRP rejected the token/key. Check both and try again.",
       "abrp_cannot_connect": "Could not reach ABRP to validate the token. Check your connection and retry.",
       "abrp_no_api_key": "Enter your ABRP API key as well as your user token — both are required to enable ABRP.",
-      "abrp_unknown": "Unexpected error validating the ABRP token."
+      "abrp_unknown": "Unexpected error validating the ABRP token.",
+      "capacity_invalid": "Enter a number for the battery capacity (kWh), or leave it blank.",
+      "capacity_out_of_range": "Battery capacity must be between 1 and 250 kWh."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -409,7 +409,9 @@
       "abrp_invalid_auth": "ABRP rechazó el token/clave. Compruébalos e inténtalo de nuevo.",
       "abrp_cannot_connect": "No se pudo contactar con ABRP para validar el token. Revisa tu conexión e inténtalo de nuevo.",
       "abrp_no_api_key": "Introduce tu clave API de ABRP además del token de usuario: ambas son obligatorias para activar ABRP.",
-      "abrp_unknown": "Error inesperado al validar el token de ABRP."
+      "abrp_unknown": "Error inesperado al validar el token de ABRP.",
+      "capacity_invalid": "Introduce un número para la capacidad de la batería (kWh) o déjalo en blanco.",
+      "capacity_out_of_range": "La capacidad de la batería debe estar entre 1 y 250 kWh."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -410,7 +410,9 @@
       "abrp_invalid_auth": "ABRP a rejeté le jeton/la clé. Vérifiez-les et réessayez.",
       "abrp_cannot_connect": "Impossible de joindre ABRP pour valider le jeton. Vérifiez votre connexion et réessayez.",
       "abrp_no_api_key": "Saisissez votre clé API ABRP en plus de votre jeton utilisateur — les deux sont requis pour activer ABRP.",
-      "abrp_unknown": "Erreur inattendue lors de la validation du jeton ABRP."
+      "abrp_unknown": "Erreur inattendue lors de la validation du jeton ABRP.",
+      "capacity_invalid": "Saisissez un nombre pour la capacité de la batterie (kWh), ou laissez vide.",
+      "capacity_out_of_range": "La capacité de la batterie doit être comprise entre 1 et 250 kWh."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -410,7 +410,9 @@
       "abrp_invalid_auth": "O ABRP rejeitou o token/chave. Verifique ambos e tente novamente.",
       "abrp_cannot_connect": "Não foi possível contactar o ABRP para validar o token. Verifique a ligacão e tente novamente.",
       "abrp_no_api_key": "Introduza a sua chave de API do ABRP além do token de utilizador — ambos são obrigatórios para ativar o ABRP.",
-      "abrp_unknown": "Erro inesperado ao validar o token ABRP."
+      "abrp_unknown": "Erro inesperado ao validar o token ABRP.",
+      "capacity_invalid": "Introduza um número para a capacidade da bateria (kWh) ou deixe em branco.",
+      "capacity_out_of_range": "A capacidade da bateria deve estar entre 1 e 250 kWh."
     }
   },
   "entity": {


### PR DESCRIPTION
## Summary
**Hotfix for `beta`.** The battery-capacity override field merged in #312 uses a schema `voluptuous_serialize` can't convert, so opening the integration's **Configure** (options) page returns `500 Internal Server Error` and the whole settings dialog fails to load:

```
ValueError: Unable to convert schema: Any('', All(Coerce(float, ...), Range(min=1, max=250, ...)))
```

`vol.Any("", ...)` isn't serializable by HA's config-flow frontend.

## Fix
Make the override a plain **text field** (which serialises, and blank clears the override) and validate/normalise on submit:
- blank → override removed;
- a valid number → stored as a float;
- non-numeric or out of range (1–250 kWh) → a friendly inline error.

Added `capacity_invalid` / `capacity_out_of_range` strings in en/es/fr/pt. `parse_capacity_override` still handles the stored value on the coordinator side.

Verified with `voluptuous_serialize` directly: the old schema raises the exact error above, the new one converts cleanly. Full suite green (173).

Fixes the options page on `beta` (regression from #312).
