### PR TITLE
feat(trip-stats): expose counter vs SOC/odometer figures side-by-side…

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Power Usage Since Last Charge
 - Mileage Since Last Charge
 - Efficiency Since Last Charge *(BEV/PHEV; km/kWh, derived from the two sensors above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
+- Efficiency Since Charge (SOC) *(BEV/PHEV; km/kWh, an SOC/odometer-only alternative independent of the counters above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
 - Last Trip Distance *(distance driven on the last completed drive)*
 - Last Trip Efficiency *(BEV/PHEV; switchable km/kWh · mi/kWh · kWh/100km, full breakdown in attributes)*
 - Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
@@ -171,9 +172,13 @@ The integration derives per-trip and per-charge efficiency from data it already 
 
 **Efficiency Since Last Charge** *(BEV/PHEV)* comes straight from the car's own `Mileage Since Last Charge` and `Power Usage Since Last Charge` figures, so it's available immediately and needs no trip tracking.
 
+**Efficiency Since Charge (SOC)** *(BEV/PHEV)* is an alternative to the sensor above, computed entirely from the odometer and battery percentage — it never touches the `Mileage Since Last Charge` / `Power Usage Since Last Charge` fields at all. It exists because those fields are unreliable on some cars (they can reset spuriously without an actual charge — see below) and permanently unpopulated (`Unknown`) on others; this sensor works either way, and lets you compare the two where both are available. Its "since charge" point is whenever the car's battery percentage was last seen to rise while parked, which may not always be a full charge to 100%.
+
 **Last Trip** sensors are populated when a drive ends (the car powers off). Distance and electric energy come from the car's own cumulative counters (`Mileage Since Last Charge` / `Power Usage Since Last Charge`), diffed between one trip and the next — so they match the car's own measurements and don't depend on exactly when the trip was detected. (For non-charging models, distance falls back to the odometer.) A charge between trips is handled automatically (the counters reset). A trip is one power-on to power-off, so a journey with a stop in the middle counts as two trips.
 
-On some cars, the since-charge counters occasionally reset on their own without an actual charge. If that happens mid-trip, the trip falls back to the odometer for distance and to the battery-percentage change for energy, and carries a `counter_reset_detected` attribute so it's visible when this happened.
+Because the counters aren't always trustworthy (see below), `Last Trip Distance` and `Last Trip Efficiency` also expose the counter-only and odometer/SOC-only figures **independently**, as attributes, alongside the primary (counter-preferred) value — so you can compare them directly for any trip: `distance_km_counter` / `distance_mi_counter` and `distance_km_odometer` / `distance_mi_odometer` on Last Trip Distance; `energy_kWh_counter` / `efficiency_km_per_kWh_counter` / `efficiency_mi_per_kWh_counter` / `consumption_kWh_per_100km_counter` / `consumption_kWh_per_100mi_counter` and the equivalent `_soc` set on Last Trip Efficiency. The counter figures are shown raw/unfiltered, even on a trip where the primary figure discarded them (see `counter_reset_detected` below) — seeing what the counter actually reported is itself useful.
+
+On some cars, the since-charge counters occasionally reset on their own without an actual charge. If that happens mid-trip, the primary trip figure falls back to the odometer for distance and to the battery-percentage change for energy, and carries a `counter_reset_detected` attribute so it's visible when this happened.
 
 If a drive is never seen live — the car wasn't polled while it was powered (a short trip that fell between polls, or a missed vehicle-start message) — the trip is reconstructed afterwards from the odometer movement once the car is next seen parked. These reconstructed trips carry `retrospective: true` and `timing: approximate` attributes, because the exact start/end times aren't known and several short hops in the same gap may be merged into one. If a trip ever gets stuck "open" (its power-off was missed), it's force-closed automatically so it doesn't block new trips.
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1452,6 +1452,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # Parked (or unknown) — a reading is needed to close or reconstruct.
         if snap is None:
             return
+        # Track the SOC-based "since reset" baseline only while parked, so a
+        # mid-drive regen SOC uptick can never be mistaken for a charge (#301:
+        # this sensor is deliberately independent of the since-charge counter
+        # fields, which are unreliable on some cars and absent on others).
+        if self.trip_stats.note_soc_reset_baseline(snap.soc_pct, snap.odometer_km, snap.ts):
+            self._schedule_trip_save()
         if open_snap is not None:
             trip = self.trip_stats.close(snap, **trip_kwargs)
             LOGGER.debug("Trip closed for VIN %s: %s", self.vin, trip)

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.7-beta1"
+  "version": "1.2.7-beta2"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -37,7 +37,7 @@ from .const import (
     DATA_100_DECIMAL_CORRECTION,
 )
 from .utils import create_device_info
-from .trip_stats import compute_since_charge_efficiency
+from .trip_stats import compute_since_charge_efficiency, compute_soc_since_reset_efficiency
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -687,6 +687,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 sensors.append(
                     SAICMGEfficiencySinceChargeSensor(coordinator, entry)
                 )
+            # SOC/odometer-based alternative — independent of the
+            # since-charge counter fields, so available on every BEV/PHEV
+            # regardless of whether those fields are reliable or populated
+            # at all on this car (#301).
+            sensors.append(SAICMGEfficiencySinceResetSensor(coordinator, entry))
         if vehicle_type in ["ICE", "HEV", "PHEV"]:
             sensors.append(
                 SAICMGLastTripSensor(
@@ -3124,6 +3129,10 @@ ENERGY_DISTANCE_DEVICE_CLASS = SensorDeviceClass.ENERGY_DISTANCE
 _TRIP_ATTR_KEYS = (
     "distance_km",
     "distance_mi",
+    "distance_km_counter",
+    "distance_mi_counter",
+    "distance_km_odometer",
+    "distance_mi_odometer",
     "duration_s",
     "soc_used_pct",
     "energy_kWh",
@@ -3131,6 +3140,16 @@ _TRIP_ATTR_KEYS = (
     "efficiency_mi_per_kWh",
     "consumption_kWh_per_100km",
     "consumption_kWh_per_100mi",
+    "energy_kWh_counter",
+    "efficiency_km_per_kWh_counter",
+    "efficiency_mi_per_kWh_counter",
+    "consumption_kWh_per_100km_counter",
+    "consumption_kWh_per_100mi_counter",
+    "energy_kWh_soc",
+    "efficiency_km_per_kWh_soc",
+    "efficiency_mi_per_kWh_soc",
+    "consumption_kWh_per_100km_soc",
+    "consumption_kWh_per_100mi_soc",
     "fuel_used_pct",
     "fuel_used_litres",
     "fuel_consumption_L_per_100km",
@@ -3289,3 +3308,82 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         return self._compute()
+
+
+class SAICMGEfficiencySinceResetSensor(CoordinatorEntity, SensorEntity):
+    """Electric efficiency since the SOC-detected reset point (#301).
+
+    An SOC/odometer-only alternative to Efficiency Since Last Charge —
+    entirely independent of the API's ``mileageSinceLastCharge`` /
+    ``powerUsageSinceLastCharge`` fields. Added because, per field reports:
+    those fields reset spuriously without an actual charge on some cars (e.g.
+    MG4), and are permanently unpopulated (``Unknown``) on others (e.g. some
+    MGS5s) — this sensor works either way, and lets the two be compared
+    directly where both are present.
+
+    The "reset point" is whenever SOC was last seen to rise while parked (a
+    charge); see TripStatsManager.note_soc_reset_baseline. As with the
+    counter-based sensor's baseline, this isn't necessarily "since a full
+    charge to 100%" (a partial charge also resets it), so it's a genuinely
+    "since reset" figure rather than a charge-accurate one — but it uses SOC
+    (reported to 0.1%) and the odometer (never resets), both of which are
+    more precise/reliable inputs than the fields it's complementing.
+    """
+
+    def __init__(self, coordinator, entry):
+        super().__init__(coordinator)
+        self._name = "Efficiency Since Charge (SOC)"
+        self._attr_icon = "mdi:gauge"
+        self._attr_device_class = ENERGY_DISTANCE_DEVICE_CLASS
+        self._attr_native_unit_of_measurement = "km/kWh"
+        self._attr_state_class = "measurement"
+        vin_info = coordinator.vin_info
+        self._unique_id = f"{entry.entry_id}_{vin_info.vin}_efficiency_since_reset_soc"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def name(self):
+        vin_info = self.coordinator.vin_info
+        return f"{vin_info.brandName} {vin_info.modelName} {self._name}"
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    def _compute(self):
+        trip_stats = self.coordinator.trip_stats
+        baseline = trip_stats.soc_reset_baseline if trip_stats else None
+        if not baseline:
+            return None
+        basic_status = self.coordinator.data.get("status")
+        charging = self.coordinator.data.get("charging")
+        current_soc = self.coordinator._extract_soc_pct(basic_status, charging)
+        current_odometer = self.coordinator._extract_odometer_km(basic_status, charging)
+        return compute_soc_since_reset_efficiency(
+            baseline.get("soc_pct"),
+            current_soc,
+            baseline.get("odometer_km"),
+            current_odometer,
+            self.coordinator.known_battery_capacity_kwh,
+        )
+
+    @property
+    def available(self):
+        # Show "unknown" (not "unavailable") when there's no baseline yet (no
+        # charge observed since the sensor started tracking) or 0 km have been
+        # driven since. The sensor is working; it just has nothing to show yet.
+        return True
+
+    @property
+    def native_value(self):
+        result = self._compute()
+        return None if result is None else result["efficiency_km_per_kWh"]
+
+    @property
+    def extra_state_attributes(self):
+        return self._compute()
+

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -142,6 +142,34 @@ def _counter_delta(current, baseline_value):
     return round(current - baseline_value, 3)
 
 
+def _efficiency_block(distance_km, distance_mi, energy_kwh):
+    """The 5-key energy/efficiency block for one (distance, energy) pairing.
+    Shared by the primary, _counter, and _soc figures so all three stay
+    consistent. Returns all-None when either input is missing/non-positive.
+    """
+    if (
+        energy_kwh is None
+        or energy_kwh <= 0
+        or distance_km is None
+        or distance_km <= 0
+    ):
+        return {
+            "energy_kWh": None,
+            "efficiency_km_per_kWh": None,
+            "efficiency_mi_per_kWh": None,
+            "consumption_kWh_per_100km": None,
+            "consumption_kWh_per_100mi": None,
+        }
+    distance_mi = distance_mi if distance_mi is not None else distance_km / KM_PER_MILE
+    return {
+        "energy_kWh": round(energy_kwh, 3),
+        "efficiency_km_per_kWh": round(distance_km / energy_kwh, 2),
+        "efficiency_mi_per_kWh": round(distance_mi / energy_kwh, 2),
+        "consumption_kWh_per_100km": round(energy_kwh / distance_km * 100.0, 2),
+        "consumption_kWh_per_100mi": round(energy_kwh / distance_mi * 100.0, 2),
+    }
+
+
 def compute_completed_trip(
     start: TripSnapshot,
     end: TripSnapshot,
@@ -172,6 +200,17 @@ def compute_completed_trip(
     flagged ``retrospective: True`` / ``timing: approximate`` so it's
     distinguishable, and its timestamps bound the gap rather than the drive.
 
+    Beyond the primary (unprefixed) distance/energy/efficiency figures — which
+    keep picking counter-preferred-with-odometer/SOC-fallback exactly as
+    before, for backward compatibility — this also exposes the counter-only
+    and odometer+SOC-only figures independently as ``*_counter`` / ``*_soc``
+    (energy) and ``distance_*_counter`` / ``distance_*_odometer`` (distance)
+    attributes, so both can be compared directly (#301: some cars' counters
+    appear to over-report energy even when not obviously reset). The counter
+    figures are raw/unfiltered here — shown even when ``counter_reset_detected``
+    discarded them from the primary selection, since a bogus counter reading is
+    itself useful to see.
+
     Returns ``None`` when no plausible distance can be established. Individual
     electric/fuel figures are ``None`` when their inputs are missing.
     """
@@ -182,20 +221,49 @@ def compute_completed_trip(
     base_kwh = baseline.get("since_charge_kwh") if baseline else None
 
     # Odometer delta is always computable and never resets mid-trip — used as
-    # the fallback distance, and as the sanity check against the counter below.
+    # the fallback distance, the odometer-side of the *_soc figures, and the
+    # sanity check against the counter below.
     odometer_delta_km = round(end.odometer_km - start.odometer_km, 2)
+    odometer_delta_mi = odometer_delta_km / KM_PER_MILE
+
+    # Raw counter-derived distance/energy — unfiltered by the reset sanity
+    # check, so the *_counter attributes show what the counter actually said
+    # even when it's discarded from the primary figures below.
+    raw_counter_km = None if retrospective else _counter_delta(end.since_charge_km, base_km)
+    raw_counter_kwh = (
+        None
+        if retrospective or not is_electric
+        else _counter_delta(end.since_charge_kwh, base_kwh)
+    )
+
+    # SOC-derived energy, computed independently whenever SOC data allows it —
+    # not just as a fallback for when the counter is missing. Paired with the
+    # odometer distance (not the counter distance) for the *_soc figures, so
+    # it's a fully self-consistent "odometer + SOC only" view.
+    soc_used_pct = None
+    soc_energy_kwh = None
+    charged_during_park = False
+    if is_electric and start.soc_pct is not None and end.soc_pct is not None:
+        soc_delta = round(start.soc_pct - end.soc_pct, 1)
+        if soc_delta < 0:
+            charged_during_park = True
+        else:
+            soc_used_pct = soc_delta
+            if capacity_kwh:
+                soc_energy_kwh = round(soc_delta / 100.0 * capacity_kwh, 3)
 
     # ── Distance: prefer the since-charge counter, else the odometer delta ────
     # Retrospective trips always use the odometer (the counter may have reset in
     # the unobserved gap).
-    counter_km = None if retrospective else _counter_delta(end.since_charge_km, base_km)
+    counter_km = raw_counter_km
 
     # Sanity check: if the odometer shows a real drive but the counter says
     # (near) nothing, the counter reset mid-trip without an actual charge — a
     # known SAIC data-quality quirk, not tied to any one model. Trusting a
     # bogus ~0 counter value here would silently drop the whole trip (0 looks
     # like valid data, not "missing"), so discard the counter for BOTH distance
-    # and energy and fall back to the odometer/SOC path instead.
+    # and energy and fall back to the odometer/SOC path instead. (This only
+    # affects the primary figures — the raw *_counter attributes still show it.)
     counter_reset_detected = (
         counter_km is not None
         and odometer_delta_km >= ODOMETER_SANITY_MIN_KM
@@ -214,6 +282,14 @@ def compute_completed_trip(
     trip: dict[str, Any] = {
         "distance_km": round(distance_km, 2),
         "distance_mi": round(distance_mi, 2),
+        # Always available regardless of which source is primary — lets any
+        # trip's distance be checked against the other source directly.
+        "distance_km_counter": round(raw_counter_km, 2) if raw_counter_km is not None else None,
+        "distance_mi_counter": (
+            round(raw_counter_km / KM_PER_MILE, 2) if raw_counter_km is not None else None
+        ),
+        "distance_km_odometer": odometer_delta_km,
+        "distance_mi_odometer": round(odometer_delta_mi, 2),
         "start_ts": start.ts,
         "end_ts": end.ts,
         "duration_s": _duration_seconds(start.ts, end.ts),
@@ -242,29 +318,30 @@ def compute_completed_trip(
 
     # ── Electric energy (BEV/PHEV) ───────────────────────────────────────────
     if is_electric:
-        # Retrospective trips, and trips where the counter reset mid-trip (see
-        # counter_reset_detected above), skip the counter and use SOC instead.
-        energy = (
-            None
-            if retrospective or counter_reset_detected
-            else _counter_delta(end.since_charge_kwh, base_kwh)
-        )
-        if energy is None and start.soc_pct is not None and end.soc_pct is not None:
-            # Derive from SOC change (coarse; the only source for retrospective
-            # trips, and the fallback when no counter is available).
-            soc_used = round(start.soc_pct - end.soc_pct, 1)
-            if soc_used < 0:
-                trip["charged_during_park"] = True
-            else:
-                trip["soc_used_pct"] = soc_used
-                if capacity_kwh:
-                    energy = round(soc_used / 100.0 * capacity_kwh, 3)
-        if energy is not None and energy > 0:
-            trip["energy_kWh"] = round(energy, 3)
-            trip["efficiency_km_per_kWh"] = round(distance_km / energy, 2)
-            trip["efficiency_mi_per_kWh"] = round(distance_mi / energy, 2)
-            trip["consumption_kWh_per_100km"] = round(energy / distance_km * 100.0, 2)
-            trip["consumption_kWh_per_100mi"] = round(energy / distance_mi * 100.0, 2)
+        trip["charged_during_park"] = charged_during_park
+        trip["soc_used_pct"] = soc_used_pct
+
+        # Primary (unprefixed): counter-preferred, SOC-fallback — unchanged
+        # behaviour from before this attribute expansion.
+        primary_energy = None if retrospective or counter_reset_detected else raw_counter_kwh
+        if primary_energy is None:
+            primary_energy = soc_energy_kwh
+        trip.update(_efficiency_block(distance_km, distance_mi, primary_energy))
+
+        # Counter-only view: counter distance + counter energy, both raw/
+        # unfiltered — a fully self-consistent "trust the counter" figure.
+        for key, value in _efficiency_block(
+            raw_counter_km, None, raw_counter_kwh
+        ).items():
+            trip[f"{key}_counter"] = value
+
+        # Odometer+SOC-only view: odometer distance + SOC energy — a fully
+        # self-consistent "trust SOC" figure, computed independently of
+        # whether the counter was available or trusted for this trip.
+        for key, value in _efficiency_block(
+            odometer_delta_km, odometer_delta_mi, soc_energy_kwh
+        ).items():
+            trip[f"{key}_soc"] = value
 
     # ── Fuel (ICE/HEV/PHEV) ──────────────────────────────────────────────────
     if is_combustion and start.fuel_pct is not None and end.fuel_pct is not None:
@@ -317,7 +394,64 @@ def compute_since_charge_efficiency(
     }
 
 
-# ── Persistent manager ───────────────────────────────────────────────────────
+def compute_soc_since_reset_efficiency(
+    baseline_soc_pct: float | None,
+    current_soc_pct: float | None,
+    baseline_odometer_km: float | None,
+    current_odometer_km: float | None,
+    capacity_kwh: float | None,
+) -> dict[str, Any] | None:
+    """Efficiency since the SOC-detected reset point, as an SOC/odometer-only
+    alternative to compute_since_charge_efficiency's counter-only figure (#301).
+
+    Independent of the car's own since-last-charge counters entirely — uses
+    only the odometer (never resets) and SOC×capacity (reported to 0.1%, so
+    accurate even over short distances). Requested because two of the fields
+    it replaces (mileageSinceLastCharge/powerUsageSinceLastCharge) are
+    reported unreliably on some cars (spurious resets) and not reported at all
+    on others (permanently Unknown, e.g. some MGS5s) — this sensor works on
+    both, since it never touches those fields.
+
+    The "reset point" here is whenever SOC was last seen to rise while parked
+    (a charge) — see TripStatsManager.note_soc_reset_baseline, which only
+    evaluates this while parked so a mid-drive regen uptick can't trigger it.
+    Because the baseline isn't necessarily "at 100% right after a full
+    charge" (a partial charge, or any other SOC rise, also triggers it), this
+    is honestly a "since reset" figure rather than a charge-accurate one, but
+    it uses the same epoch boundary as the counter-based figure it's
+    replacing/complementing.
+
+    Returns ``None`` when there's no baseline yet or SOC hasn't dropped.
+    """
+    if (
+        baseline_soc_pct is None
+        or current_soc_pct is None
+        or baseline_odometer_km is None
+        or current_odometer_km is None
+    ):
+        return None
+    distance_km = round(current_odometer_km - baseline_odometer_km, 2)
+    soc_used_pct = round(baseline_soc_pct - current_soc_pct, 1)
+    if distance_km <= 0 or soc_used_pct <= 0 or not capacity_kwh:
+        return None
+    energy_kwh = round(soc_used_pct / 100.0 * capacity_kwh, 3)
+    if energy_kwh <= 0:
+        return None
+    distance_mi = distance_km / KM_PER_MILE
+    return {
+        "distance_km": distance_km,
+        "distance_mi": round(distance_mi, 2),
+        "soc_used_pct": soc_used_pct,
+        "baseline_soc_pct": baseline_soc_pct,
+        "energy_kWh": energy_kwh,
+        "efficiency_km_per_kWh": round(distance_km / energy_kwh, 2),
+        "efficiency_mi_per_kWh": round(distance_mi / energy_kwh, 2),
+        "consumption_kWh_per_100km": round(energy_kwh / distance_km * 100.0, 2),
+        "consumption_kWh_per_100mi": round(energy_kwh / distance_mi * 100.0, 2),
+    }
+
+
+
 
 # HA imports are done lazily inside methods so the pure functions above can be
 # imported and unit-tested without Home Assistant installed.
@@ -356,6 +490,11 @@ class TripStatsManager:
         # reconstruct trips that were never seen live (the car wasn't polled
         # while powered) — see detect_missed_trip.
         self.last_parked_snapshot: TripSnapshot | None = None
+        # SOC/odometer at the last-seen "since reset" epoch boundary — a charge
+        # (SOC rise) observed while parked. Powers the SOC-based Efficiency
+        # Since Charge (SOC) sensor, entirely independent of the since-charge
+        # counter fields — see note_soc_reset_baseline.
+        self.soc_reset_baseline: dict[str, Any] | None = None
 
     async def async_load(self) -> None:
         from homeassistant.helpers.storage import Store
@@ -370,6 +509,7 @@ class TripStatsManager:
         self.last_parked_snapshot = TripSnapshot.from_dict(
             data.get("last_parked_snapshot")
         )
+        self.soc_reset_baseline = data.get("soc_reset_baseline")
 
     async def async_save(self) -> None:
         """Persist current open/last-trip state and the since-charge baseline."""
@@ -387,6 +527,7 @@ class TripStatsManager:
                     if self.last_parked_snapshot
                     else None
                 ),
+                "soc_reset_baseline": self.soc_reset_baseline,
             }
         )
 
@@ -409,6 +550,29 @@ class TripStatsManager:
             self.since_charge_baseline = {
                 "since_charge_km": round(km, 3),
                 "since_charge_kwh": round(kwh, 3) if kwh is not None else 0.0,
+            }
+            return True
+        return False
+
+    def note_soc_reset_baseline(self, soc_pct, odometer_km, ts) -> bool:
+        """Track SOC while parked to detect a charge (SOC rise) and rebase the
+        SOC-based "since reset" baseline — the odometer/SOC-only counterpart to
+        note_since_charge, entirely independent of the since-charge counter
+        fields (#301: those are unreliable on some cars, absent on others).
+
+        Only ever called while parked (the coordinator gates this), so a
+        mid-drive regen SOC uptick can never be mistaken for a charge here.
+        Returns True if the baseline changed (caller may persist).
+        """
+        if soc_pct is None or odometer_km is None:
+            return False
+        if self.soc_reset_baseline is None or soc_pct > self.soc_reset_baseline.get(
+            "soc_pct", -1.0
+        ):
+            self.soc_reset_baseline = {
+                "soc_pct": round(soc_pct, 1),
+                "odometer_km": round(odometer_km, 3),
+                "ts": ts,
             }
             return True
         return False

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -317,6 +317,132 @@ class TestCounterBasedTrip(unittest.TestCase):
         self.assertNotIn("counter_reset_detected", trip)
 
 
+class TestParallelCounterSocFigures(unittest.TestCase):
+    """The *_counter / *_soc comparison attributes (#301)."""
+
+    def _snap(self, odo, since_km=None, since_kwh=None, soc=None, t="2026-08-20T06:36:00+00:00"):
+        return Snap(ts=t, odometer_km=odo, soc_pct=soc,
+                    since_charge_km=since_km, since_charge_kwh=since_kwh)
+
+    def test_counter_and_soc_sets_both_present_and_independent(self):
+        # Reproduces SteveMSJ's report: the counter over-reports energy (17%
+        # high here) relative to the SOC-based figure, even with no reset —
+        # both should be exposed, self-consistently paired with their own
+        # distance source, alongside the existing primary (counter-preferred).
+        start = self._snap(1000.0, since_km=0.0, since_kwh=0.0, soc=100.0)
+        end = self._snap(1341.0, since_km=341.0, since_kwh=59.1, soc=18.4,
+                         t="2026-08-20T12:00:00+00:00")
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 0.0, "since_charge_kwh": 0.0},
+            capacity_kwh=61.7, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        # Primary stays counter-preferred (unchanged behaviour).
+        self.assertEqual(trip["distance_km"], 341.0)
+        self.assertEqual(trip["energy_kWh"], 59.1)
+
+        # Counter-only set: counter distance + counter energy.
+        self.assertEqual(trip["distance_km_counter"], 341.0)
+        self.assertEqual(trip["energy_kWh_counter"], 59.1)
+
+        # Odometer-only distance always present.
+        self.assertEqual(trip["distance_km_odometer"], 341.0)
+        self.assertAlmostEqual(trip["distance_mi_odometer"], 341.0 / ts.KM_PER_MILE, places=2)
+
+        # SOC-only set: odometer distance + SOC×capacity energy — matches
+        # Steve's manual calc (81.6% x 61.7 = 50.3 kWh), independent of the
+        # counter's 59.1 kWh (a ~17% discrepancy, visible by comparing the two).
+        self.assertAlmostEqual(trip["energy_kWh_soc"], 50.35, places=1)
+        self.assertLess(trip["energy_kWh_soc"], trip["energy_kWh_counter"])
+
+    def test_counter_reset_still_exposes_raw_bogus_counter_value(self):
+        # Even when the primary figure discards a reset counter reading, the
+        # raw (bogus) counter value should still be visible in *_counter —
+        # seeing "the counter said 0" is itself useful, not something to hide.
+        start = self._snap(1100.0, since_km=56.5, since_kwh=14.6, soc=57.7)
+        end = self._snap(1191.0, since_km=0.0, since_kwh=0.0, soc=40.8,
+                         t="2026-08-20T14:58:10+00:00")
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 0.0, "since_charge_kwh": 0.0},
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertTrue(trip["counter_reset_detected"])
+        self.assertEqual(trip["distance_km"], 91.0)  # primary fell back to odometer
+        # Raw counter figures still shown (0 - 0 = 0), distinguishable via the flag.
+        self.assertEqual(trip["distance_km_counter"], 0.0)
+        self.assertIsNone(trip["energy_kWh_counter"])  # 0 energy -> no valid ratio
+        # SOC-based set is unaffected and gives a real figure.
+        self.assertAlmostEqual(trip["energy_kWh_soc"], 16.9 / 100 * 64.0, places=2)
+
+    def test_no_soc_data_leaves_soc_set_none(self):
+        start = self._snap(1000.0, since_km=0.0, since_kwh=0.0)  # no soc
+        end = self._snap(1020.0, since_km=20.0, since_kwh=3.0)
+        trip = ts.compute_completed_trip(
+            start, end, baseline={"since_charge_km": 0.0, "since_charge_kwh": 0.0},
+            capacity_kwh=64.0, tank_litres=None, is_electric=True, is_combustion=False,
+        )
+        self.assertIsNone(trip["energy_kWh_soc"])
+        self.assertIsNone(trip["efficiency_km_per_kWh_soc"])
+
+
+class TestSocSinceResetEfficiency(unittest.TestCase):
+    """compute_soc_since_reset_efficiency — the pure SOC/odometer-only calc."""
+
+    def test_basic_calculation(self):
+        result = ts.compute_soc_since_reset_efficiency(
+            baseline_soc_pct=100.0, current_soc_pct=18.4,
+            baseline_odometer_km=1000.0, current_odometer_km=1341.0,
+            capacity_kwh=61.7,
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["distance_km"], 341.0)
+        self.assertAlmostEqual(result["energy_kWh"], 50.35, places=1)
+        self.assertEqual(result["baseline_soc_pct"], 100.0)
+
+    def test_no_baseline_returns_none(self):
+        self.assertIsNone(ts.compute_soc_since_reset_efficiency(
+            None, 50.0, None, 1000.0, 64.0
+        ))
+
+    def test_no_movement_returns_none(self):
+        self.assertIsNone(ts.compute_soc_since_reset_efficiency(
+            80.0, 80.0, 1000.0, 1000.0, 64.0
+        ))
+
+    def test_soc_rose_since_baseline_returns_none(self):
+        # A further charge happened without the baseline being rebased yet —
+        # shouldn't report negative/nonsensical energy.
+        self.assertIsNone(ts.compute_soc_since_reset_efficiency(
+            50.0, 60.0, 1000.0, 1010.0, 64.0
+        ))
+
+
+class TestNoteSocResetBaseline(unittest.TestCase):
+    def _mgr(self):
+        from unittest.mock import MagicMock
+        return ts.TripStatsManager(MagicMock(), "e", "V")
+
+    def test_seeds_on_first_call(self):
+        m = self._mgr()
+        self.assertTrue(m.note_soc_reset_baseline(80.0, 1000.0, "t1"))
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 80.0)
+
+    def test_rebases_on_soc_rise_only(self):
+        m = self._mgr()
+        m.note_soc_reset_baseline(50.0, 1000.0, "t1")
+        # SOC dropped (driving happened) -> no rebase.
+        self.assertFalse(m.note_soc_reset_baseline(40.0, 1010.0, "t2"))
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 50.0)
+        # SOC rose (a charge) -> rebase.
+        self.assertTrue(m.note_soc_reset_baseline(100.0, 1010.0, "t3"))
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 100.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 1010.0)
+
+    def test_none_soc_is_a_no_op(self):
+        m = self._mgr()
+        self.assertFalse(m.note_soc_reset_baseline(None, 1000.0, "t1"))
+        self.assertIsNone(m.soc_reset_baseline)
+
+
 class TestNoteSinceCharge(unittest.TestCase):
     def _mgr(self):
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
Adds side-by-side counter-vs-SOC comparison figures, following the discussion in #301 with SteveMSJ and joaommarques. **Deliberately doesn't change which figure is primary anywhere** — this is about gathering comparable data before deciding whether the default should change.

## Background
- Both users report the since-charge counters (`Mileage Since Last Charge` / `Power Usage Since Last Charge`) resetting spuriously without a charge on their MG4s (already mitigated by #315's odometer fallback).
- SteveMSJ's MGS5 shows these fields as permanently `Unknown` — the car just doesn't populate them.
- More significantly: SteveMSJ compared the counter-derived energy against a SOC-drop × capacity calculation on a real 212-mile trip with **no reset involved**, and found the counter reads **~17% high** (59.1 kWh vs 50.3 kWh SOC-based — and the car's own dash efficiency matched the SOC-based figure, not the counter). joaommarques sees the same pattern on his MG4.

## Changes

**1. `Last Trip Distance` / `Last Trip Efficiency`** — `compute_completed_trip` now always computes the counter-derived and odometer/SOC-derived figures independently (not just as a sequential fallback), exposing full parallel attribute sets:
- `distance_km_counter` / `distance_mi_counter` (raw, shown even when `counter_reset_detected` discarded it from the primary figure) and `distance_km_odometer` / `distance_mi_odometer`
- `energy_kWh_counter` + 4 derived `_counter` efficiency/consumption figures (self-consistent: counter distance + counter energy)
- `energy_kWh_soc` + 4 derived `_soc` figures (self-consistent: odometer distance + SOC energy)

The existing primary `distance_km` / `energy_kWh` / `efficiency_*` / `consumption_*` keys are **unchanged** — still counter-preferred with odometer/SOC fallback — so nothing breaks for existing dashboards or automations.

**2. New sensor: `Efficiency Since Charge (SOC)`** — an SOC/odometer-only alternative to `Efficiency Since Last Charge`, entirely independent of the counter fields. Available on every BEV/PHEV regardless of whether those fields are reliable or populated at all on a given car. Its epoch boundary (battery % last seen to rise while parked) is tracked completely separately from the existing counter-reset logic via new `TripStatsManager.note_soc_reset_baseline`, and only evaluated while parked so a mid-drive regen SOC uptick can never be mistaken for a charge.

## Tests
Parallel-figure computation (including SteveMSJ's exact 212-mile numbers as a regression case), raw-counter-value-still-shown-through-a-reset, missing-SOC-data handling, the new pure function (4 cases), and the new baseline-tracking method (3 cases). **197 tests green** (187 existing unchanged + 10 new).

## Not in this PR
Whether to change the *default*/primary figure. That's an open decision for #301 pending more comparisons across users.