### PR TITLE
Feat/soc based efficiency comparison

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.7-beta2"
+  "version": "1.2.7-beta3"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -667,6 +667,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 UnitOfLength.KILOMETERS,
                 "mdi:map-marker-distance",
                 "measurement",
+                with_attributes=True,
             )
         )
         if vehicle_type in ["BEV", "PHEV"]:


### PR DESCRIPTION
**Fix:** `Last Trip Distance` wasn't exposing any trip attributes at all (a pre-existing gap, not new in this release) — it now shows the full set alongside Last Trip Efficiency and Last Trip Fuel Economy.