### PR TITLE
chore(india): bump client to 0.1.6

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.5"
+    "mg-ismart-india-client==0.1.6"
   ],
   "version": "1.2.7-beta3"
 }


### PR DESCRIPTION
Bumps the pinned India client `0.1.5` → `0.1.6`.

Release: [john-lazarus/mg-ismart-india-client@d424c7f](https://github.com/john-lazarus/mg-ismart-india-client/commit/d424c7f918b4253c1c41ab1ba5c6268a4747adf5)

**What's in 0.1.6:** EV charging status support — `MgIndiaClient.charge_status()` returning a decoded `ChargeStatus`, plus a typed `ChargingStatusUnavailable` error. Additive only; no existing API changed, so nothing in the integration breaks on this bump alone.

Unblocks #302, which consumes `charge_status()`.
