### PR TITLE
fix(sensors): unbreak Efficiency Since Charge (SOC) + the 3x energy correction, add Last Charge Energy (#262)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Mileage Since Last Charge
 - Efficiency Since Last Charge *(BEV/PHEV; km/kWh, derived from the two sensors above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
 - Efficiency Since Charge (SOC) *(BEV/PHEV; km/kWh, an SOC/odometer-only alternative independent of the counters above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
+- Last Charge Energy *(BEV/PHEV; kWh put **into** the battery by the last completed charge — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
 - Last Trip Distance *(distance driven on the last completed drive)*
 - Last Trip Efficiency *(BEV/PHEV; switchable km/kWh · mi/kWh · kWh/100km, full breakdown in attributes)*
 - Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
@@ -173,6 +174,15 @@ The integration derives per-trip and per-charge efficiency from data it already 
 **Efficiency Since Last Charge** *(BEV/PHEV)* comes straight from the car's own `Mileage Since Last Charge` and `Power Usage Since Last Charge` figures, so it's available immediately and needs no trip tracking.
 
 **Efficiency Since Charge (SOC)** *(BEV/PHEV)* is an alternative to the sensor above, computed entirely from the odometer and battery percentage — it never touches the `Mileage Since Last Charge` / `Power Usage Since Last Charge` fields at all. It exists because those fields are unreliable on some cars (they can reset spuriously without an actual charge — see below) and permanently unpopulated (`Unknown`) on others; this sensor works either way, and lets you compare the two where both are available. Its "since charge" point is whenever the car's battery percentage was last seen to rise while parked, which may not always be a full charge to 100%.
+
+**Last Charge Energy** *(BEV/PHEV)* reports how much energy the last completed charge put **into** the battery. The API has no field for this — it reports charging power live, and `Power Usage Since Last Charge` (energy taken back *out* afterwards), but there is no "starting power" to subtract from `lastChargeEndingPower` — so the session is measured across its start and end. Two independent figures are produced, and both appear in the attributes:
+
+- `energy_added_kWh_soc` — the rise in battery percentage × the usable capacity. This is the headline value, because it works on any car that reports SOC and has a known capacity (see [Battery capacity override](#battery-capacity-override) if yours is wrong).
+- `energy_added_kWh_counter` — the change in the car's own pack-energy figure (`lastChargeEndingPower` minus `Power Usage Since Last Charge`). Independent of the capacity figure, but it relies on the car refreshing `lastChargeEndingPower` promptly when the charge ends, so it's omitted when it doesn't look plausible.
+
+Also in the attributes: `soc_start_pct`, `soc_end_pct`, `soc_added_pct`, `duration_s`, `average_power_kW`, `method` (which figure was used), and the session's start/end timestamps. A `mg_saic_charge_completed` event fires when a charge finishes, carrying the same data, so you can log or notify on it.
+
+Note this is energy measured **at the battery**, so it will read lower than a wall meter or smart charger, which also pay for charger and cable losses. A charge that delivers less than 0.5% is ignored (that's the small percentage rebound the pack reports after a drive, not a charge), and a session left open more than 48 hours is abandoned rather than reported. A charging-data dropout is never mistaken for the end of a charge — on some cars the charging endpoint goes quiet the moment a session completes.
 
 **Last Trip** sensors are populated when a drive ends (the car powers off). Distance and electric energy come from the car's own cumulative counters (`Mileage Since Last Charge` / `Power Usage Since Last Charge`), diffed between one trip and the next — so they match the car's own measurements and don't depend on exactly when the trip was detected. (For non-charging models, distance falls back to the odometer.) A charge between trips is handled automatically (the counters reset). A trip is one power-on to power-off, so a journey with a stop in the middle counts as two trips.
 

--- a/RELEASE_NOTES_1.2.7-beta5.md
+++ b/RELEASE_NOTES_1.2.7-beta5.md
@@ -1,0 +1,38 @@
+# 1.2.7-beta5
+
+Two fixes that affect every car, and one new sensor. All three came out of [discussion #262](https://github.com/townsmcp/mg-saic-ha/discussions/262) — thanks to @HarryFlatter for the detail.
+
+## Fixed: Efficiency Since Charge (SOC) never showed a value
+
+This sensor has been stuck on `Unknown` since it was introduced — on **all** models, not just PHEVs, and regardless of how much you'd driven since charging.
+
+Two separate faults were stacked on top of each other. The sensor was handing the wrong object to its odometer lookup, and that lookup's backup route was searching a part of the API response that doesn't contain an odometer at all. With no odometer reading, the sensor had nothing to calculate a distance from, so it never produced a figure.
+
+Both are fixed. The underlying charge-detection was working correctly all along, so the sensor starts reporting as soon as you've driven after a charge.
+
+## Fixed: Power Usage Since Last Charge still ~3× too high on MG HS PHEV
+
+The correction for this was added in 1.2.6, but it was applied in a code path this particular sensor never takes — so in practice nothing changed and the sensor kept showing the inflated figure. It's now applied wherever the value is read.
+
+On an HS PHEV, a reading like 20.20 kWh should have been around 6.9 kWh.
+
+Two related sensors — `Efficiency Since Last Charge` and the `Last Trip` energy figures — were already correcting this properly and were never affected. If you have an HS PHEV and your energy figures looked inconsistent with each other, this is why.
+
+## New: Last Charge Energy sensor *(BEV/PHEV)*
+
+Tells you how much energy the last completed charge put **into** the battery. Useful when you've charged somewhere that isn't home and want to know what you actually took — the car reports charging power while it's happening, and how much you've used *since* charging, but nothing about the charge itself.
+
+The API has no field for this, so the integration measures it across the charging session. Two independent figures are calculated and both appear in the sensor's attributes:
+
+- **From battery percentage** — the rise in charge level against your car's usable capacity. This is the headline value, as it works on any car that reports a battery percentage. If your `Total Battery Capacity` looks wrong, set a [battery capacity override](https://github.com/townsmcp/mg-saic-ha#battery-capacity-override) and this will follow it.
+- **From the car's own energy figures** — shown alongside for comparison, and omitted when it doesn't look trustworthy.
+
+Also in the attributes: start and end battery percentage, percentage added, how long the charge took, average power, and the session's timestamps. A `mg_saic_charge_completed` event fires at the end of each charge carrying the same data, so you can notify or log on it.
+
+**Worth knowing:** this is energy measured at the battery, so it will read lower than your wall meter, Zappi or similar — those also pay for charger and cable losses. Expect a gap of roughly 5–10%.
+
+Some deliberate limits: charges that add less than 0.5% are ignored (that's the small rebound the pack reports after a drive rather than a real charge), and a session left open more than 48 hours is dropped rather than reported as a nonsense number. Crucially, a charging-data dropout is never mistaken for the end of a charge — on some cars the charging endpoint goes quiet the instant a session finishes, which would otherwise log a phantom charge every time.
+
+## Upgrading
+
+No action needed. The Last Charge Energy sensor appears after a restart and populates once it has seen a complete charge from start to finish — so it will read `Unknown` until your next charge finishes.

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -1051,6 +1051,11 @@ MILEAGE_UINT16_SATURATION = 65535
 # frequent refresh cadence as AC/DC charging sessions.
 CHARGING_STATUS_CODES = {1, 3, 10, 12, 13}
 
+# Statuses that count as energy going INTO the battery, for the Last Charge
+# Energy session tracking (#262). Deliberately excludes 13 (V2X_DISCHARGING):
+# that is energy flowing the other way, so it must never open a charge session.
+CHARGE_SESSION_STATUS_CODES = {1, 3, 10, 12}
+
 # Charging Current Limit options
 CHARGING_CURRENT_OPTIONS = ["0A (Ignore)", "6A", "8A", "16A", "Max"]
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -12,7 +12,7 @@ from .api import SAICMGAPIClient, CommandsLimitReachedException
 from .backends import Feature
 from .backends import backend_supports as _backend_supports
 from .logic import select_update_interval
-from .trip_stats import TripStatsManager, TripSnapshot
+from .trip_stats import TripStatsManager, TripSnapshot, ChargeSnapshot
 
 # After the car turns off, fire extra refreshes at these intervals (seconds)
 # to catch plug-in as quickly as possible.  The coordinator is still on its
@@ -28,6 +28,7 @@ from .const import (
     MILEAGE_UINT16_SATURATION,
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
     CHARGING_STATUS_CODES,
+    CHARGE_SESSION_STATUS_CODES,
     CONF_ABRP_API_KEY,
     CONF_ABRP_USER_TOKEN,
     DEFAULT_AC_LONG_INTERVAL,
@@ -1377,10 +1378,14 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             raw = getattr(source, "mileage", None) if source is not None else None
             if raw is not None and raw > 0 and raw != MILEAGE_UINT16_SATURATION:
                 return raw * factor
-        # Fall back to the wider odometer field in charging data.
-        chrg = getattr(charging_data, "chrgMgmtData", None) if charging_data else None
-        raw = getattr(chrg, "mileage", None) if chrg is not None else None
-        if raw is not None and raw > 0:
+        # Fall back to the odometer in the charging data. This lives on
+        # rvsChargeStatus (the same block as mileageSinceLastCharge) — NOT on
+        # chrgMgmtData, which carries the BMS fields and has no mileage at all,
+        # so the previous lookup here could never succeed and this fallback was
+        # silently dead.
+        rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
+        raw = getattr(rcs, "mileage", None) if rcs is not None else None
+        if raw is not None and raw > 0 and raw != MILEAGE_UINT16_SATURATION:
             return raw * DATA_DECIMAL_CORRECTION
         return None
 
@@ -1474,6 +1479,71 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             elif was_seeded:
                 self._schedule_trip_save()
 
+    def _extract_pack_energy_kwh(self, charging_data):
+        """Energy currently held in the pack (kWh), per the car's own figures.
+
+        ``lastChargeEndingPower`` is what the pack held when the last charge
+        finished; ``powerUsageSinceLastCharge`` is what has been taken out
+        since. The difference is therefore the energy in the pack right now,
+        and it holds at both charge boundaries — at the end of a charge the
+        since-charge counter is ~0, so it collapses to lastChargeEndingPower.
+
+        Both fields are inflated ~3× on some models, so both get the profile's
+        charging_capacity_correction (#262). Returns None if either is missing.
+        """
+        rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
+        if rcs is None:
+            return None
+        raw = getattr(rcs, "lastChargeEndingPower", None)
+        if raw is None or raw < 0:
+            return None
+        ending = raw * DATA_DECIMAL_CORRECTION
+        if self.charging_capacity_correction is not None:
+            ending = ending * self.charging_capacity_correction
+        _, used = self._extract_since_charge(charging_data)
+        return ending - (used or 0.0)
+
+    def _charge_snapshot(self, basic_status, charging_data):
+        """Build a ChargeSnapshot for the charge-session tracker, or None."""
+        return ChargeSnapshot(
+            ts=datetime.now(timezone.utc).isoformat(),
+            soc_pct=self._extract_soc_pct(basic_status, charging_data),
+            pack_energy_kwh=self._extract_pack_energy_kwh(charging_data),
+            odometer_km=self._extract_odometer_km(basic_status, charging_data),
+        )
+
+    def _update_charge_state(self, basic_status, charging_data):
+        """Open/close a charging session so Last Charge Energy can report how
+        much went IN — the API has no such field (#262, @HarryFlatter).
+
+        Only ever evaluated when the charging endpoint actually answered. A
+        failed charging fetch drops charging_data to None and would look
+        identical to the charge ending, and on some cars that endpoint goes
+        quiet the instant a session completes — so a dropout must not be
+        allowed to close (or open) a session.
+        """
+        if self.trip_stats is None:
+            return
+        chrg_mgmt_data = (
+            getattr(charging_data, "chrgMgmtData", None) if charging_data else None
+        )
+        if chrg_mgmt_data is None:
+            return
+        status = getattr(chrg_mgmt_data, "bmsChrgSts", None)
+        if status is None:
+            return
+        charge, changed = self.trip_stats.note_charge_state(
+            status in CHARGE_SESSION_STATUS_CODES,
+            self._charge_snapshot(basic_status, charging_data),
+            capacity_kwh=self.known_battery_capacity_kwh,
+            now_iso=datetime.now(timezone.utc).isoformat(),
+        )
+        if charge is not None:
+            LOGGER.debug("Charge session completed for VIN %s: %s", self.vin, charge)
+            self.trip_stats.fire_charge_event(charge)
+        if changed:
+            self._schedule_trip_save()
+
     def _schedule_trip_save(self):
         """Persist trip state in the background (best-effort)."""
         try:
@@ -1540,6 +1610,14 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self.is_charging = (
                     getattr(chrg_mgmt_data, "bmsChrgSts", None) in CHARGING_STATUS_CODES
                 )
+
+        # Charge-session tracking for Last Charge Energy (#262). Runs before
+        # the transition handling below because it needs the raw charging data
+        # to distinguish a real charge-stop from the endpoint dropping out.
+        self._update_charge_state(
+            getattr(status_data, "basicVehicleStatus", None) if status_data else None,
+            charging_data,
+        )
 
         # A charging -> not-charging transition (charge complete, or the
         # charging endpoint dropping out) is registered as activity so the

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.7-beta3"
+  "version": "1.2.7-beta4"
 }

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.5"
   ],
-  "version": "1.2.7-beta4"
+  "version": "1.2.7-beta5"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -688,6 +688,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 sensors.append(
                     SAICMGEfficiencySinceChargeSensor(coordinator, entry)
                 )
+                # How much energy the last charge put IN (#262) — measured
+                # across the session, since the API only reports energy taken
+                # back out afterwards.
+                sensors.append(SAICMGLastChargeEnergySensor(coordinator, entry))
             # SOC/odometer-based alternative — independent of the
             # since-charge counter fields, so available on every BEV/PHEV
             # regardless of whether those fields are reliable or populated
@@ -2226,6 +2230,29 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
     # _NOT_CHARGING_ZERO_FIELDS above should return 0 explicitly.
     # V2X_DISCHARGING (13) is deliberately absent — it has live current/voltage data.
     _INACTIVE_CHARGING_STATUSES = frozenset({0, 5})
+    # Energy fields that some models (e.g. MG HS PHEV / AS33P) report inflated
+    # by ~3× relative to the true kWh — the same quirk that makes
+    # totalBatteryCapacity read 72.5 kWh on a 24.7 kWh pack. The per-profile
+    # charging_capacity_correction factor brings them back to real kWh.
+    _CORRECTED_ENERGY_FIELDS = frozenset(
+        {"lastChargeEndingPower", "powerUsageSinceLastCharge"}
+    )
+
+    def _apply_energy_correction(self, value):
+        """Scale an inflated energy field by the profile's correction factor.
+
+        Applied from BOTH numeric branches below. It previously lived only
+        inside the _NOT_CHARGING_ZERO_FIELDS branch, which
+        powerUsageSinceLastCharge never enters — so that sensor kept showing
+        the raw ~3× figure on affected models (#262, @HarryFlatter: 20.20 kWh
+        reported against a 24.7 kWh pack after ~39 km).
+        """
+        if value is None or self._field not in self._CORRECTED_ENERGY_FIELDS:
+            return value
+        correction = getattr(self.coordinator, "charging_capacity_correction", None)
+        if correction is None:
+            return value
+        return value * correction
 
     def __init__(
         self,
@@ -2334,21 +2361,7 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
                             return self._last_valid_value
                         return None
                     if raw_value is not None:
-                        result = raw_value * self._factor
-                        # lastChargeEndingPower / powerUsageSinceLastCharge: some
-                        # models (e.g. HS PHEV) report these energy fields inflated
-                        # by ~3× relative to the true kWh value. Apply the profile's
-                        # charging_capacity_correction factor when set so the
-                        # displayed value matches the real battery.
-                        if self._field in (
-                            "lastChargeEndingPower",
-                            "powerUsageSinceLastCharge",
-                        ):
-                            correction = getattr(
-                                self.coordinator, "charging_capacity_correction", None
-                            )
-                            if correction is not None:
-                                result = result * correction
+                        result = self._apply_energy_correction(raw_value * self._factor)
                         self._last_valid_value = result
                         return result
                     return None
@@ -2427,7 +2440,12 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
                             return self._last_valid_value
                         return None
                     if raw_value is not None:
-                        result = raw_value * self._factor if self._factor is not None else raw_value
+                        result = (
+                            raw_value * self._factor
+                            if self._factor is not None
+                            else raw_value
+                        )
+                        result = self._apply_energy_correction(result)
                         self._last_valid_value = result
                         return result
                     # raw_value is None — fall through to retention below
@@ -3311,6 +3329,88 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
         return self._compute()
 
 
+class SAICMGLastChargeEnergySensor(CoordinatorEntity, SensorEntity):
+    """Energy delivered into the battery by the last completed charge (#262).
+
+    The API reports charging power live, and ``powerUsageSinceLastCharge``
+    (energy taken *out* since the charge), but has no field for how much a
+    charge put *in* — there is no ``lastChargeStartingPower`` to subtract
+    from ``lastChargeEndingPower``. So the session is measured across its
+    start/end boundaries by the coordinator; see
+    trip_stats.compute_charge_session for the two methods and their tradeoffs.
+
+    This is energy measured at the *battery*, so it will read lower than a
+    wall meter or a smart charger, which also pay for charger and cable
+    losses. Handy when charging away from home and settling up with whoever's
+    electricity you borrowed.
+    """
+
+    _CHARGE_ATTR_KEYS = (
+        "energy_added_kWh",
+        "energy_added_kWh_soc",
+        "energy_added_kWh_counter",
+        "method",
+        "soc_start_pct",
+        "soc_end_pct",
+        "soc_added_pct",
+        "duration_s",
+        "average_power_kW",
+        "odometer_km",
+        "start_ts",
+        "end_ts",
+    )
+
+    def __init__(self, coordinator, entry):
+        super().__init__(coordinator)
+        self._name = "Last Charge Energy"
+        self._attr_icon = "mdi:battery-charging-medium"
+        self._attr_device_class = SensorDeviceClass.ENERGY
+        self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+        # "measurement", not total_increasing: this is a per-session figure
+        # that goes up and down with each charge, not a running total.
+        self._attr_state_class = "measurement"
+        vin_info = coordinator.vin_info
+        self._unique_id = f"{entry.entry_id}_{vin_info.vin}_last_charge_energy"
+        self._device_info = create_device_info(coordinator, entry.entry_id)
+
+    @property
+    def unique_id(self):
+        return self._unique_id
+
+    @property
+    def name(self):
+        vin_info = self.coordinator.vin_info
+        return f"{vin_info.brandName} {vin_info.modelName} {self._name}"
+
+    @property
+    def device_info(self):
+        return self._device_info
+
+    def _charge(self):
+        stats = getattr(self.coordinator, "trip_stats", None)
+        return stats.last_charge if stats is not None else None
+
+    @property
+    def available(self):
+        # Show "unknown" rather than dropping out before the first charge has
+        # been observed end-to-end — the sensor works, it just has nothing yet.
+        return True
+
+    @property
+    def native_value(self):
+        charge = self._charge()
+        return charge.get("energy_added_kWh") if charge else None
+
+    @property
+    def extra_state_attributes(self):
+        charge = self._charge()
+        if not charge:
+            return None
+        return {
+            k: charge.get(k) for k in self._CHARGE_ATTR_KEYS if charge.get(k) is not None
+        }
+
+
 class SAICMGEfficiencySinceResetSensor(CoordinatorEntity, SensorEntity):
     """Electric efficiency since the SOC-detected reset point (#301).
 
@@ -3360,7 +3460,12 @@ class SAICMGEfficiencySinceResetSensor(CoordinatorEntity, SensorEntity):
         baseline = trip_stats.soc_reset_baseline if trip_stats else None
         if not baseline:
             return None
-        basic_status = self.coordinator.data.get("status")
+        # NB: the extractors take basicVehicleStatus, not the top-level status
+        # object — passing the latter made the odometer lookup miss (mileage
+        # lives on basicVehicleStatus), which returned None and left this
+        # sensor permanently Unknown on every car.
+        status = self.coordinator.data.get("status")
+        basic_status = getattr(status, "basicVehicleStatus", None)
         charging = self.coordinator.data.get("charging")
         current_soc = self.coordinator._extract_soc_pct(basic_status, charging)
         current_odometer = self.coordinator._extract_odometer_km(basic_status, charging)

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -41,6 +41,15 @@ from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Any
 
+# Minimum SOC rise (%) for a plugged-in period to be recorded as a charge.
+# Filters out a plug-in that delivered nothing and the small SOC rebound the
+# pack reports after a drive.
+MIN_CHARGE_SOC_PCT = 0.5
+
+# Abandon (rather than record) a charge session left open longer than this —
+# a missed charge-stop shouldn't produce a nonsense figure days later.
+MAX_OPEN_CHARGE_SECONDS = 48 * 3600
+
 # Reject an odometer delta larger than this (km) as a single trip — protects
 # against odometer rollover, the uint16 saturation sentinel slipping through,
 # or a garbage reading. A genuine single drive won't exceed this.
@@ -112,6 +121,46 @@ class TripSnapshot:
                 fuel_pct=_f("fuel_pct"),
                 since_charge_km=_f("since_charge_km"),
                 since_charge_kwh=_f("since_charge_kwh"),
+            )
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+@dataclass
+class ChargeSnapshot:
+    """A reading taken at the start or end of a charging session (#262).
+
+    ``pack_energy_kwh`` is the car's own estimate of the energy sitting in the
+    pack, derived as ``lastChargeEndingPower - powerUsageSinceLastCharge``
+    (both already decimal-corrected, and scaled by the per-model energy
+    correction where one applies). That identity holds at both boundaries: at
+    the end of a charge the since-charge counter is ~0, so the expression
+    collapses to lastChargeEndingPower itself.
+    """
+
+    ts: str  # ISO-8601 timestamp string (storage-friendly)
+    soc_pct: float | None = None
+    pack_energy_kwh: float | None = None
+    odometer_km: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any] | None) -> "ChargeSnapshot | None":
+        if not d:
+            return None
+
+        def _f(key):
+            v = d.get(key)
+            return None if v is None else float(v)
+
+        try:
+            return cls(
+                ts=d["ts"],
+                soc_pct=_f("soc_pct"),
+                pack_energy_kwh=_f("pack_energy_kwh"),
+                odometer_km=_f("odometer_km"),
             )
         except (KeyError, TypeError, ValueError):
             return None
@@ -453,11 +502,87 @@ def compute_soc_since_reset_efficiency(
 
 
 
+def compute_charge_session(
+    start: "ChargeSnapshot",
+    end: "ChargeSnapshot",
+    *,
+    capacity_kwh: float | None,
+) -> dict[str, Any] | None:
+    """Energy delivered into the battery during one charging session (#262).
+
+    Requested by @HarryFlatter: the API reports charging *power* live and
+    ``powerUsageSinceLastCharge`` (energy taken *out* since the last charge),
+    but nothing for "how much did that charge put *in*" — which is what you
+    need when you're charging on someone else's supply and want to settle up.
+    There is no ``lastChargeStartingPower`` field to subtract, so it has to be
+    measured across the session.
+
+    Two independent figures are produced, in the same
+    show-both-and-let-the-car-tell-us style as the trip sensors:
+
+    * ``soc``     — (SOC rise) × usable capacity. Always available on a car
+      that reports SOC and has a known capacity, and SOC is reported to 0.1 %.
+    * ``counter`` — the delta of the car's own pack-energy figure
+      (``lastChargeEndingPower - powerUsageSinceLastCharge``). Independent of
+      the capacity we hold for the model, but it relies on the car refreshing
+      lastChargeEndingPower promptly at the end of the session.
+
+    The SOC figure is the headline value because it is available on every
+    model; the counter figure rides along as an attribute so the two can be
+    compared on real cars. Both are *battery-side* energy — always less than
+    the energy drawn at the wall, which also covers charger and cable losses.
+
+    Returns ``None`` when neither method can produce a plausible figure.
+    """
+    if start is None or end is None:
+        return None
+
+    result: dict[str, Any] = {"start_ts": start.ts, "end_ts": end.ts}
+
+    duration_s = _duration_seconds(start.ts, end.ts)
+    if duration_s is not None:
+        result["duration_s"] = duration_s
+
+    energy_soc = None
+    if start.soc_pct is not None and end.soc_pct is not None:
+        soc_added = round(end.soc_pct - start.soc_pct, 1)
+        result["soc_start_pct"] = start.soc_pct
+        result["soc_end_pct"] = end.soc_pct
+        result["soc_added_pct"] = soc_added
+        if soc_added >= MIN_CHARGE_SOC_PCT and capacity_kwh:
+            energy_soc = round(soc_added / 100.0 * capacity_kwh, 3)
+
+    energy_counter = None
+    if start.pack_energy_kwh is not None and end.pack_energy_kwh is not None:
+        delta = round(end.pack_energy_kwh - start.pack_energy_kwh, 3)
+        # Guard against the car not having refreshed lastChargeEndingPower yet
+        # (delta <= 0) or reporting something larger than the pack can hold.
+        if delta > 0 and (capacity_kwh is None or delta <= capacity_kwh * 1.05):
+            energy_counter = delta
+
+    if energy_soc is None and energy_counter is None:
+        return None
+
+    energy = energy_soc if energy_soc is not None else energy_counter
+    result["energy_added_kWh"] = energy
+    result["method"] = "soc" if energy_soc is not None else "counter"
+    if energy_soc is not None:
+        result["energy_added_kWh_soc"] = energy_soc
+    if energy_counter is not None:
+        result["energy_added_kWh_counter"] = energy_counter
+    if start.odometer_km is not None:
+        result["odometer_km"] = start.odometer_km
+    if duration_s and duration_s > 0 and energy:
+        result["average_power_kW"] = round(energy / (duration_s / 3600.0), 2)
+    return result
+
+
 # HA imports are done lazily inside methods so the pure functions above can be
 # imported and unit-tested without Home Assistant installed.
 
 STORAGE_VERSION = 1
 EVENT_TRIP_COMPLETED = "mg_saic_trip_completed"
+EVENT_CHARGE_COMPLETED = "mg_saic_charge_completed"
 
 
 class TripStatsManager:
@@ -495,6 +620,11 @@ class TripStatsManager:
         # Since Charge (SOC) sensor, entirely independent of the since-charge
         # counter fields — see note_soc_reset_baseline.
         self.soc_reset_baseline: dict[str, Any] | None = None
+        # Charging-session tracking (#262): the snapshot taken when a charge
+        # started, and the last completed charge. Powers the Last Charge Energy
+        # sensor — the API has no "energy added by that charge" field.
+        self.open_charge: ChargeSnapshot | None = None
+        self.last_charge: dict[str, Any] | None = None
 
     async def async_load(self) -> None:
         from homeassistant.helpers.storage import Store
@@ -510,6 +640,8 @@ class TripStatsManager:
             data.get("last_parked_snapshot")
         )
         self.soc_reset_baseline = data.get("soc_reset_baseline")
+        self.open_charge = ChargeSnapshot.from_dict(data.get("open_charge"))
+        self.last_charge = data.get("last_charge")
 
     async def async_save(self) -> None:
         """Persist current open/last-trip state and the since-charge baseline."""
@@ -528,6 +660,10 @@ class TripStatsManager:
                     else None
                 ),
                 "soc_reset_baseline": self.soc_reset_baseline,
+                "open_charge": (
+                    self.open_charge.to_dict() if self.open_charge else None
+                ),
+                "last_charge": self.last_charge,
             }
         )
 
@@ -576,6 +712,53 @@ class TripStatsManager:
             }
             return True
         return False
+
+    def note_charge_state(
+        self,
+        is_charging: bool,
+        snapshot: "ChargeSnapshot | None",
+        *,
+        capacity_kwh: float | None,
+        now_iso: str,
+    ) -> tuple[dict[str, Any] | None, bool]:
+        """Open/close a charging session (#262).
+
+        Returns ``(completed_charge_or_None, state_changed)``; the caller
+        persists when state_changed and fires an event for a completed charge.
+
+        Called only on polls where charging data was actually returned — a
+        failed charging fetch drops charging_data to None and flips is_charging
+        to False, which would otherwise look exactly like the charge ending.
+        That matters here: on some cars (#262) the charging endpoint reliably
+        goes quiet the moment a session completes, so treating a dropout as an
+        end-of-charge would record a phantom session on every outage.
+        """
+        if snapshot is None:
+            return None, False
+
+        if is_charging:
+            if self.open_charge is None:
+                self.open_charge = snapshot
+                return None, True
+            # Already charging — nothing to do. The start snapshot stands.
+            return None, False
+
+        if self.open_charge is None:
+            return None, False
+
+        start = self.open_charge
+        self.open_charge = None
+
+        age = _duration_seconds(start.ts, now_iso)
+        if age is not None and age > MAX_OPEN_CHARGE_SECONDS:
+            # A charge-stop we never saw. Abandon rather than invent a figure.
+            return None, True
+
+        charge = compute_charge_session(start, snapshot, capacity_kwh=capacity_kwh)
+        if charge is None:
+            return None, True
+        self.last_charge = charge
+        return charge, True
 
     def open(self, snapshot: TripSnapshot) -> bool:
         """Record the start-of-drive snapshot (synchronous). Returns True if a
@@ -722,6 +905,16 @@ class TripStatsManager:
         try:
             self._hass.bus.async_fire(
                 EVENT_TRIP_COMPLETED, {"vin": self._vin, **trip}
+            )
+        except Exception:  # noqa: BLE001 - event firing must never break a poll
+            pass
+
+    def fire_charge_event(self, charge: dict[str, Any]) -> None:
+        """Fire mg_saic_charge_completed so automations can react to a finished
+        charge (#262) — the same contract as the trip event."""
+        try:
+            self._hass.bus.async_fire(
+                EVENT_CHARGE_COMPLETED, {"vin": self._vin, **charge}
             )
         except Exception:  # noqa: BLE001 - event firing must never break a poll
             pass

--- a/reply-to-harry.md
+++ b/reply-to-harry.md
@@ -1,0 +1,58 @@
+@HarryFlatter — all three of these turned out to be real, and two of them are worse than you thought (they affect every car, not just yours). Fixed in #330, going out as **1.2.7-beta5**.
+
+## 1. Efficiency Since Charge (SOC) — not a PHEV thing
+
+You said it looked "absent for PHEV". It isn't — the entity is created for BEV and PHEV alike, so you do have it. It just never produces a value **on any car**. I checked mine: charged Friday night, 61 km driven since, and it's been sat on `Unknown` the entire time too.
+
+Two bugs stacked on top of each other:
+
+- The sensor was passing the wrong object into its odometer and SOC lookups. SOC got away with it because it has a fallback to the charging data; the odometer didn't.
+- That odometer fallback was then looking for `mileage` in the wrong part of the response. I checked the client library schema to be sure: `mileage`, `mileageOfDay` and `mileageSinceLastCharge` all live in `rvsChargeStatus`, not where we were looking. So the fallback could never have worked.
+
+No odometer, no distance, no value — every time. The charge-detection behind it was working perfectly all along, which is why it was so unobvious. Both fixed, and it'll populate as soon as you've driven after a charge.
+
+## 2. Power Usage Since Last Charge — you were right, and right about why
+
+Your instinct that this smelled like the earlier 3× bug was correct, though the mechanism was different this time. The correction **does** exist and it's the right number — it was just added in a place this particular sensor never reaches. So it was dead code and the sensor carried on showing the raw figure.
+
+Your numbers back it out exactly: 20.20 kWh corrected is **~6.9 kWh**, which fits 24 miles against a 53-of-75 mile range readout. Now applied wherever the value is read.
+
+Worth knowing which sensors were affected: `Efficiency Since Last Charge` and the `Last Trip` energy figures were already correcting this properly and were always right. Only the standalone Power Usage sensor was wrong — so if those looked inconsistent with each other on your dashboard, that's the explanation.
+
+On `lastChargeEndingPower=725` — good spot, and yes, that's the same 3× inflation (725 → 72.5 kWh → ~24.7 kWh real). To answer your question directly: **there is no `lastChargeStartingPower`.** I went through the full field list for both charging blocks; nothing of the sort exists. Which brings us to:
+
+## 3. Last Charge Energy — new sensor, your suggestion
+
+Since there's no starting figure to subtract, the only way to get this is to measure it across the charging session, so that's what it now does. It gives you two independent numbers, both in the attributes:
+
+- **From battery percentage** — SOC rise × usable capacity. This is the headline value since it works on every car.
+- **From the car's own energy figures** — `lastChargeEndingPower` minus `Power Usage Since Last Charge`, which is effectively the energy sitting in the pack. Shown alongside for comparison, and dropped when it doesn't look trustworthy.
+
+Plus start/end/added percentage, duration, average power, and timestamps. There's also a `mg_saic_charge_completed` event firing at the end of each charge with the same data, which should suit your dashboard.
+
+One caveat for your granny-charging use case: **this is energy at the battery, not at the wall.** Your Zappi will always read higher, because it's also paying for charger and cable losses — typically 5–10%, more on a slow granny charge in the cold. So it'll get you close for settling up with your friend, but it's a floor, not a meter reading.
+
+Your car's charging dropout got specifically designed around, incidentally. Because your charging endpoint goes quiet the instant a session completes, a naive implementation would log a phantom charge every single time that happened. Session tracking now only acts on polls where the charging data actually came back.
+
+## On the capacity — you got there before I could ask
+
+I was going to ask you to check whether you had an override set, because 24.70 didn't match the profile. You've answered it: override deleted, now on 23.2. That's the right call and it makes your Last Charge Energy figures correct from the start.
+
+One correction though, because it matters for trusting the number: **SAIC hasn't started reporting 23.2.** The car still reports the same inflated 725 it always has. The 23.2 is a figure *we* hold in the vehicle profile for the AS33P — the real usable capacity, as opposed to the 24.7 nominal pack size from the brochure. So nothing changed at SAIC's end; you've just switched from the brochure number to the usable one, which is the more honest basis for energy maths (you can't actually use all 24.7).
+
+## And your arithmetic checks out
+
+    27.9% of 23.2 kWh = 6.47 kWh
+    20.20 kWh / 3     = 6.73 kWh
+
+Close enough — yes, and usefully so. Those are two genuinely independent routes to the same number (battery percentage against known capacity, versus the car's own energy counter with the correction applied) landing within about 4% of each other. That's the first real-world confirmation I've had that the correction factor is right, so thank you — it's exactly the cross-check I couldn't do on my own car, since mine doesn't have the inflation.
+
+It's also mildly interesting that the SOC route reads slightly *lower*. With one data point I'm not going to start tuning the factor on the strength of it, but if you fancy jotting down both figures over your next few charges, that would tell us whether the 4% is a consistent bias worth correcting or just noise. No obligation.
+
+## On the version — sorry, that one's my fault
+
+Good catch, and the confusion is entirely mine. Here's what happened: when I released beta4 on the 27th I tagged and published the release, but didn't bump the version inside the integration's manifest, which was still reading beta3. So the release you installed says beta4 (that's what HACS shows you) while the code inside thinks it's beta3.
+
+I then wrote the PR against that manifest and bumped what I thought was beta3 → beta4 — straight into a version number that already existed and that you were already running. So no, beta4 hasn't been patched; my PR was about to create a second, different beta4, which would have been thoroughly confusing for everyone.
+
+**Fixed — these three changes will land as 1.2.7-beta5.** I'll post here when it's up.

--- a/tests/test_charge_stats.py
+++ b/tests/test_charge_stats.py
@@ -1,0 +1,191 @@
+# File: tests/test_charge_stats.py
+"""Unit tests for the charge-session maths in trip_stats (#262).
+
+Covers the Last Charge Energy feature: how much energy a charge put *into*
+the battery, which the API has no field for (there is no
+``lastChargeStartingPower`` to subtract from ``lastChargeEndingPower``), so
+it has to be measured across the session.
+
+Imports only the pure functions and the manager's session bookkeeping, both
+of which are free of Home Assistant deps — matching python-tests.yaml CI.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ts = _load("mg_saic_charge_stats_under_test", PKG_DIR / "trip_stats.py")
+CSnap = ts.ChargeSnapshot
+
+
+def csnap(soc=None, pack=None, odo=None, t="2026-08-29T22:00:00+00:00"):
+    return CSnap(ts=t, soc_pct=soc, pack_energy_kwh=pack, odometer_km=odo)
+
+
+class TestComputeChargeSession(unittest.TestCase):
+    def test_soc_based_energy_added(self):
+        start = csnap(soc=36.9, t="2026-08-28T18:30:00+00:00")
+        end = csnap(soc=80.0, t="2026-08-28T23:38:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=74.3)
+        self.assertIsNotNone(charge)
+        self.assertEqual(charge["soc_added_pct"], 43.1)
+        # 43.1 % of 74.3 kWh
+        self.assertAlmostEqual(charge["energy_added_kWh"], 32.023, places=3)
+        self.assertEqual(charge["method"], "soc")
+        self.assertEqual(charge["duration_s"], 18480)
+
+    def test_counter_figure_exposed_alongside_soc(self):
+        start = csnap(soc=50.0, pack=30.0)
+        end = csnap(soc=80.0, pack=52.0, t="2026-08-29T23:00:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=74.3)
+        self.assertAlmostEqual(charge["energy_added_kWh_soc"], 22.29, places=2)
+        self.assertAlmostEqual(charge["energy_added_kWh_counter"], 22.0, places=2)
+        # SOC is the headline figure; the counter rides along for comparison.
+        self.assertEqual(charge["method"], "soc")
+        self.assertEqual(charge["energy_added_kWh"], charge["energy_added_kWh_soc"])
+
+    def test_counter_used_when_soc_unavailable(self):
+        start = csnap(pack=10.0)
+        end = csnap(pack=18.5, t="2026-08-29T23:00:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=24.7)
+        self.assertEqual(charge["method"], "counter")
+        self.assertAlmostEqual(charge["energy_added_kWh"], 8.5, places=2)
+
+    def test_stale_ending_power_is_rejected(self):
+        """If the car hasn't refreshed lastChargeEndingPower yet the pack-energy
+        delta is <= 0 — that must not be reported as a charge."""
+        start = csnap(soc=50.0, pack=40.0)
+        end = csnap(soc=80.0, pack=40.0, t="2026-08-29T23:00:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=74.3)
+        self.assertNotIn("energy_added_kWh_counter", charge)
+        self.assertEqual(charge["method"], "soc")
+
+    def test_counter_larger_than_pack_is_rejected(self):
+        start = csnap(pack=10.0)
+        end = csnap(pack=200.0, t="2026-08-29T23:00:00+00:00")
+        self.assertIsNone(
+            ts.compute_charge_session(start, end, capacity_kwh=24.7)
+        )
+
+    def test_trivial_soc_rise_is_not_a_charge(self):
+        """The pack rebounds a fraction of a percent after a drive — that is
+        not a charge and must not produce an energy figure."""
+        start = csnap(soc=66.0)
+        end = csnap(soc=66.2, t="2026-08-29T23:00:00+00:00")
+        self.assertIsNone(
+            ts.compute_charge_session(start, end, capacity_kwh=74.3)
+        )
+
+    def test_no_capacity_falls_back_to_counter(self):
+        start = csnap(soc=40.0, pack=12.0)
+        end = csnap(soc=90.0, pack=24.0, t="2026-08-29T23:00:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=None)
+        self.assertEqual(charge["method"], "counter")
+        self.assertAlmostEqual(charge["energy_added_kWh"], 12.0, places=2)
+
+    def test_average_power(self):
+        start = csnap(soc=50.0, t="2026-08-29T20:00:00+00:00")
+        end = csnap(soc=60.0, t="2026-08-29T22:00:00+00:00")
+        charge = ts.compute_charge_session(start, end, capacity_kwh=74.0)
+        # 7.4 kWh over 2 h
+        self.assertAlmostEqual(charge["average_power_kW"], 3.7, places=2)
+
+
+class _Manager(ts.TripStatsManager):
+    """Manager with persistence/event plumbing bypassed for the pure logic."""
+
+    def __init__(self):
+        self.open_charge = None
+        self.last_charge = None
+
+
+class TestNoteChargeState(unittest.TestCase):
+    def setUp(self):
+        self.m = _Manager()
+
+    def _note(self, charging, snapshot, now="2026-08-29T23:00:00+00:00"):
+        return self.m.note_charge_state(
+            charging, snapshot, capacity_kwh=74.3, now_iso=now
+        )
+
+    def test_full_session_open_and_close(self):
+        charge, changed = self._note(
+            True, csnap(soc=40.0, t="2026-08-29T20:00:00+00:00")
+        )
+        self.assertIsNone(charge)
+        self.assertTrue(changed)
+        self.assertIsNotNone(self.m.open_charge)
+
+        charge, changed = self._note(
+            False, csnap(soc=80.0, t="2026-08-29T23:00:00+00:00")
+        )
+        self.assertIsNotNone(charge)
+        self.assertTrue(changed)
+        self.assertIsNone(self.m.open_charge)
+        self.assertEqual(self.m.last_charge, charge)
+        self.assertAlmostEqual(charge["energy_added_kWh"], 29.72, places=2)
+
+    def test_start_snapshot_is_not_overwritten_mid_charge(self):
+        self._note(True, csnap(soc=40.0, t="2026-08-29T20:00:00+00:00"))
+        charge, changed = self._note(
+            True, csnap(soc=60.0, t="2026-08-29T21:30:00+00:00")
+        )
+        self.assertIsNone(charge)
+        self.assertFalse(changed)
+        self.assertEqual(self.m.open_charge.soc_pct, 40.0)
+
+    def test_missing_snapshot_is_ignored(self):
+        """A poll with no usable reading must not open or close anything —
+        this is the charging-endpoint dropout guard."""
+        self._note(True, csnap(soc=40.0, t="2026-08-29T20:00:00+00:00"))
+        charge, changed = self._note(False, None)
+        self.assertIsNone(charge)
+        self.assertFalse(changed)
+        self.assertIsNotNone(self.m.open_charge)
+
+    def test_not_charging_with_no_open_session_is_a_no_op(self):
+        charge, changed = self._note(False, csnap(soc=66.0))
+        self.assertIsNone(charge)
+        self.assertFalse(changed)
+
+    def test_stale_open_session_is_abandoned(self):
+        self._note(True, csnap(soc=40.0, t="2026-08-25T20:00:00+00:00"))
+        charge, changed = self._note(
+            False, csnap(soc=80.0, t="2026-08-29T23:00:00+00:00")
+        )
+        self.assertIsNone(charge)
+        self.assertTrue(changed)
+        self.assertIsNone(self.m.open_charge)
+        self.assertIsNone(self.m.last_charge)
+
+    def test_plug_in_that_delivered_nothing_records_no_charge(self):
+        self._note(True, csnap(soc=66.0, t="2026-08-29T20:00:00+00:00"))
+        charge, changed = self._note(
+            False, csnap(soc=66.1, t="2026-08-29T21:00:00+00:00")
+        )
+        self.assertIsNone(charge)
+        self.assertTrue(changed)
+        self.assertIsNone(self.m.last_charge)
+
+    def test_snapshot_roundtrips_through_storage(self):
+        snap = csnap(soc=40.0, pack=30.0, odo=12345.6)
+        restored = CSnap.from_dict(snap.to_dict())
+        self.assertEqual(restored, snap)
+        self.assertIsNone(CSnap.from_dict(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes three issues raised by @HarryFlatter in #262 on an MG HS PHEV (AS33P). Two of them affect every car, not just PHEVs.

### 1. Efficiency Since Charge (SOC) never produced a value

Reported as "absent for PHEV", but the entity is created for BEV and PHEV alike — it was returning no value **on every car**, including a BEV with a completed charge and 61 km driven since.

Two stacked faults:

- `SAICMGEfficiencySinceResetSensor._compute` passed `coordinator.data["status"]` (the top-level object) into `_extract_soc_pct` / `_extract_odometer_km`, which both expect `basicVehicleStatus`. SOC survived because it falls back to the charging data; the odometer did not.
- `_extract_odometer_km`'s charging-data fallback looked for `mileage` on `chrgMgmtData`, which has no such field. Confirmed against the `mg-saic-client` 0.9.4 schema: `mileage`, `mileageOfDay` and `mileageSinceLastCharge` all live on `rvsChargeStatus`. That fallback has never worked.

Result: `current_odometer` was always `None`, so `_compute` always returned `None`. The `soc_reset_baseline` tracking itself was fine — verified recording correctly through a real charge (36.9% → 80.0%).

### 2. Power Usage Since Last Charge still 3x too high

The `charging_capacity_correction` added in #310 was placed inside the `_NOT_CHARGING_ZERO_FIELDS` branch, but `powerUsageSinceLastCharge` isn't in that set (only `lastChargeEndingPower` is). It therefore fell through to the generic numeric branch, which applies the x0.1 factor and nothing else, so the correction was unreachable dead code.

Harry's 20.20 kWh is the uncorrected figure; corrected it's ~6.9 kWh, consistent with his 24 miles and 53-of-75 mile range readout.

Hoisted into a shared `_apply_energy_correction()` called from both numeric branches. Note the coordinator path (`_extract_since_charge`) and the Efficiency Since Last Charge sensor were already applying it correctly — only the standalone sensor was affected.

### 3. New: Last Charge Energy sensor

Harry asked for the energy a charge put **into** the battery, which the API doesn't report — there's no `lastChargeStartingPower` to subtract from `lastChargeEndingPower` (full `RvsChargeStatus` / `ChrgMgmtData` field lists checked). So the session is measured across its start/end boundaries.

Two figures, in the same show-both style as the trip sensors:

- `energy_added_kWh_soc` — SOC rise x usable capacity. Headline value; works on any car reporting SOC with a known capacity.
- `energy_added_kWh_counter` — delta of the car's own pack energy (`lastChargeEndingPower - powerUsageSinceLastCharge`). That identity holds at both boundaries, since the since-charge counter is ~0 at the end of a charge. Dropped when implausible (e.g. the car hasn't refreshed `lastChargeEndingPower` yet).

Plus `soc_start_pct` / `soc_end_pct` / `soc_added_pct`, `duration_s`, `average_power_kW`, `method`, and start/end timestamps. Fires `mg_saic_charge_completed`.

Guards:

- **A charging-data dropout is never treated as the end of a charge.** On Harry's car the charging endpoint reliably goes quiet the instant a session completes, which would otherwise log a phantom charge on every outage.
- V2X discharging (status 13) can't open a session.
- Charges delivering under 0.5% SOC are ignored (post-drive pack rebound).
- Sessions left open over 48h are abandoned rather than reported.

This is battery-side energy, so it reads lower than a wall meter or smart charger — charger and cable losses aren't visible to the car. Documented in the README.

### Testing

15 new unit tests in `tests/test_charge_stats.py` covering the session maths and open/close bookkeeping, including the dropout guard, the stale-`lastChargeEndingPower` rejection and the trivial-SOC-rise filter. Full suite passes (2 pre-existing unrelated import errors on `beta` are unchanged).

Version bumped to 1.2.7-beta4.