### PR TITLE
refactor: move the energy correction and odometer lookup into logic.py (#262)

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.util.dt import utcnow
 from .api import SAICMGAPIClient, CommandsLimitReachedException
 from .backends import Feature
 from .backends import backend_supports as _backend_supports
-from .logic import select_update_interval
+from .logic import apply_energy_correction, odometer_km, select_update_interval
 from .trip_stats import TripStatsManager, TripSnapshot, ChargeSnapshot
 
 # After the car turns off, fire extra refreshes at these intervals (seconds)
@@ -1367,27 +1367,26 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         so apply the profile's charging_capacity_correction to the ENERGY only —
         distance is never inflated — giving real kWh for trip energy/efficiency."""
         km, kwh = self._extract_since_charge_raw(charging_data)
-        if kwh is not None and self.charging_capacity_correction is not None:
-            kwh = kwh * self.charging_capacity_correction
+        kwh = apply_energy_correction(
+            "powerUsageSinceLastCharge", kwh, self.charging_capacity_correction
+        )
         return km, kwh
 
     @staticmethod
     def _extract_odometer_km(basic_status, charging_data):
-        """Odometer in km, or None. Rejects 0/-128 and the uint16 saturation."""
-        for source, factor in ((basic_status, DATA_DECIMAL_CORRECTION),):
-            raw = getattr(source, "mileage", None) if source is not None else None
-            if raw is not None and raw > 0 and raw != MILEAGE_UINT16_SATURATION:
-                return raw * factor
-        # Fall back to the odometer in the charging data. This lives on
-        # rvsChargeStatus (the same block as mileageSinceLastCharge) — NOT on
-        # chrgMgmtData, which carries the BMS fields and has no mileage at all,
-        # so the previous lookup here could never succeed and this fallback was
-        # silently dead.
-        rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
-        raw = getattr(rcs, "mileage", None) if rcs is not None else None
-        if raw is not None and raw > 0 and raw != MILEAGE_UINT16_SATURATION:
-            return raw * DATA_DECIMAL_CORRECTION
-        return None
+        """Odometer in km, or None. Rejects 0/-128 and the uint16 saturation.
+
+        Delegates to logic.odometer_km so the source preference and the
+        fallback order are unit-testable without Home Assistant — see #262,
+        where the charging-data fallback read a field that doesn't exist and
+        nothing caught it because nothing could test it directly.
+        """
+        return odometer_km(
+            basic_status,
+            charging_data,
+            factor=DATA_DECIMAL_CORRECTION,
+            saturation=MILEAGE_UINT16_SATURATION,
+        )
 
     @staticmethod
     def _extract_soc_pct(basic_status, charging_data):
@@ -1497,9 +1496,11 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         raw = getattr(rcs, "lastChargeEndingPower", None)
         if raw is None or raw < 0:
             return None
-        ending = raw * DATA_DECIMAL_CORRECTION
-        if self.charging_capacity_correction is not None:
-            ending = ending * self.charging_capacity_correction
+        ending = apply_energy_correction(
+            "lastChargeEndingPower",
+            raw * DATA_DECIMAL_CORRECTION,
+            self.charging_capacity_correction,
+        )
         _, used = self._extract_since_charge(charging_data)
         return ending - (used or 0.0)
 

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -92,3 +92,54 @@ def select_update_interval(
         raise TypeError("default_update_interval must be a timedelta")
 
     return default_update_interval
+
+
+# Energy fields that some models (e.g. MG HS PHEV / AS33P) report inflated by
+# ~3× — the same quirk that makes totalBatteryCapacity read 72.5 kWh on a
+# 24.7 kWh pack. The profile's charging_capacity_correction is applied to each
+# of these wherever they are read (#262, #310).
+ENERGY_CORRECTION_FIELDS = frozenset(
+    {"lastChargeEndingPower", "powerUsageSinceLastCharge"}
+)
+
+
+def apply_energy_correction(field, value, correction):
+    """Scale an inflated energy field by the per-model correction factor.
+
+    Returns ``value`` unchanged for fields that aren't inflated, for models
+    with no correction configured, or for a missing value. Distance fields are
+    never corrected — only the energy fields above.
+
+    Lives here rather than on the sensor because it has to be applied from
+    several call sites (both numeric branches of the charging sensor, and the
+    coordinator's charge-session maths). Keeping one implementation is what
+    stops a repeat of #310, where the correction was added in a branch the
+    field never reached and so silently did nothing.
+    """
+    if value is None or correction is None:
+        return value
+    if field not in ENERGY_CORRECTION_FIELDS:
+        return value
+    return value * correction
+
+
+def odometer_km(basic_status, charging_data, *, factor, saturation):
+    """Odometer in km from a poll's data, or None.
+
+    Prefers ``basicVehicleStatus.mileage``, then falls back to the odometer
+    carried in the charging data. The fallback reads ``rvsChargeStatus``,
+    which is where ``mileage`` actually lives — ``chrgMgmtData`` has no such
+    field, so looking there (as this once did) meant the fallback could never
+    fire, and any caller relying on it got None (#262).
+
+    Rejects 0, negatives and the uint16 saturation sentinel.
+    """
+    raw = getattr(basic_status, "mileage", None) if basic_status is not None else None
+    if raw is not None and raw > 0 and raw != saturation:
+        return raw * factor
+    if charging_data is not None:
+        source = getattr(charging_data, "rvsChargeStatus", None)
+        raw = getattr(source, "mileage", None) if source is not None else None
+        if raw is not None and raw > 0 and raw != saturation:
+            return raw * factor
+    return None

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -36,6 +36,7 @@ from .const import (
     CHARGING_VOLTAGE_FACTOR,
     DATA_100_DECIMAL_CORRECTION,
 )
+from .logic import apply_energy_correction
 from .utils import create_device_info
 from .trip_stats import compute_since_charge_efficiency, compute_soc_since_reset_efficiency
 
@@ -2230,14 +2231,6 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
     # _NOT_CHARGING_ZERO_FIELDS above should return 0 explicitly.
     # V2X_DISCHARGING (13) is deliberately absent — it has live current/voltage data.
     _INACTIVE_CHARGING_STATUSES = frozenset({0, 5})
-    # Energy fields that some models (e.g. MG HS PHEV / AS33P) report inflated
-    # by ~3× relative to the true kWh — the same quirk that makes
-    # totalBatteryCapacity read 72.5 kWh on a 24.7 kWh pack. The per-profile
-    # charging_capacity_correction factor brings them back to real kWh.
-    _CORRECTED_ENERGY_FIELDS = frozenset(
-        {"lastChargeEndingPower", "powerUsageSinceLastCharge"}
-    )
-
     def _apply_energy_correction(self, value):
         """Scale an inflated energy field by the profile's correction factor.
 
@@ -2246,13 +2239,16 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
         powerUsageSinceLastCharge never enters — so that sensor kept showing
         the raw ~3× figure on affected models (#262, @HarryFlatter: 20.20 kWh
         reported against a 24.7 kWh pack after ~39 km).
+
+        The field list and the maths live in logic.apply_energy_correction, so
+        the coordinator's charge-session figures and this sensor can't drift
+        apart, and the rule is unit-testable without Home Assistant.
         """
-        if value is None or self._field not in self._CORRECTED_ENERGY_FIELDS:
-            return value
-        correction = getattr(self.coordinator, "charging_capacity_correction", None)
-        if correction is None:
-            return value
-        return value * correction
+        return apply_energy_correction(
+            self._field,
+            value,
+            getattr(self.coordinator, "charging_capacity_correction", None),
+        )
 
     def __init__(
         self,

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -131,5 +131,99 @@ class SelectUpdateIntervalTests(unittest.TestCase):
         self.assertEqual(interval, self.default_interval)
 
 
+class ApplyEnergyCorrectionTests(unittest.TestCase):
+    """The ~3x energy inflation correction (#262, #310).
+
+    Regression cover for a fix that was silently doing nothing: the correction
+    existed and was the right number, but sat in a code path
+    powerUsageSinceLastCharge never took, so the sensor kept reporting the raw
+    figure. Pinning the field list here means a future refactor that drops a
+    field fails loudly.
+    """
+
+    def test_corrects_power_usage_since_last_charge(self):
+        # Harry's HS PHEV: 20.20 kWh reported, ~6.73 kWh real (#262).
+        self.assertAlmostEqual(
+            LOGIC.apply_energy_correction("powerUsageSinceLastCharge", 20.20, 1 / 3),
+            6.733,
+            places=3,
+        )
+
+    def test_corrects_last_charge_ending_power(self):
+        self.assertAlmostEqual(
+            LOGIC.apply_energy_correction("lastChargeEndingPower", 72.5, 1 / 3),
+            24.167,
+            places=3,
+        )
+
+    def test_leaves_uncorrected_fields_alone(self):
+        # Distance is never inflated, only the energy fields.
+        self.assertEqual(
+            LOGIC.apply_energy_correction("mileageSinceLastCharge", 38.6, 1 / 3), 38.6
+        )
+
+    def test_no_correction_configured_is_a_passthrough(self):
+        self.assertEqual(
+            LOGIC.apply_energy_correction("powerUsageSinceLastCharge", 10.0, None), 10.0
+        )
+
+    def test_missing_value_stays_none(self):
+        self.assertIsNone(
+            LOGIC.apply_energy_correction("powerUsageSinceLastCharge", None, 1 / 3)
+        )
+
+    def test_zero_is_corrected_not_treated_as_missing(self):
+        self.assertEqual(
+            LOGIC.apply_energy_correction("powerUsageSinceLastCharge", 0.0, 1 / 3), 0.0
+        )
+
+
+class OdometerKmTests(unittest.TestCase):
+    """Odometer source preference and fallback order (#262).
+
+    The charging-data fallback used to read chrgMgmtData, which carries no
+    mileage field at all, so it could never fire — and nothing noticed because
+    the logic wasn't reachable from a test. It is now.
+    """
+
+    FACTOR = 0.1
+    SATURATION = 65535
+
+    def _odo(self, basic=None, charging=None):
+        return LOGIC.odometer_km(
+            basic, charging, factor=self.FACTOR, saturation=self.SATURATION
+        )
+
+    def test_prefers_basic_vehicle_status(self):
+        basic = SimpleNamespace(mileage=123456)
+        charging = SimpleNamespace(rvsChargeStatus=SimpleNamespace(mileage=999))
+        self.assertAlmostEqual(self._odo(basic, charging), 12345.6)
+
+    def test_falls_back_to_rvs_charge_status(self):
+        charging = SimpleNamespace(rvsChargeStatus=SimpleNamespace(mileage=123456))
+        self.assertAlmostEqual(self._odo(None, charging), 12345.6)
+
+    def test_chrg_mgmt_data_carries_no_odometer(self):
+        # The original bug: chrgMgmtData has no mileage field, so a fallback
+        # pointed at it yields nothing.
+        charging = SimpleNamespace(chrgMgmtData=SimpleNamespace(bmsPackSOCDsp=661))
+        self.assertIsNone(self._odo(None, charging))
+
+    def test_rejects_zero_and_negative(self):
+        self.assertIsNone(self._odo(SimpleNamespace(mileage=0)))
+        self.assertIsNone(self._odo(SimpleNamespace(mileage=-128)))
+
+    def test_rejects_uint16_saturation(self):
+        self.assertIsNone(self._odo(SimpleNamespace(mileage=self.SATURATION)))
+
+    def test_saturated_basic_status_falls_through_to_charging(self):
+        basic = SimpleNamespace(mileage=self.SATURATION)
+        charging = SimpleNamespace(rvsChargeStatus=SimpleNamespace(mileage=123456))
+        self.assertAlmostEqual(self._odo(basic, charging), 12345.6)
+
+    def test_no_data_at_all(self):
+        self.assertIsNone(self._odo(None, None))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Follow-up to #330. **No behaviour change** — this moves two rules into `logic.py` and puts tests on them.

### Why

Both bugs fixed in #330 shared a root cause: the rule that mattered was buried where no test could reach it.

- The **energy correction** lived in one branch of `SAICMGChargingSensor`'s numeric handler. That's how #310 could add it to a branch `powerUsageSinceLastCharge` never takes and have it silently do nothing for two releases.
- The **odometer lookup** lived inside a coordinator `@staticmethod`. That's how its charging-data fallback could point at `chrgMgmtData` — which has no `mileage` field at all — and never fire, for as long as nobody noticed Efficiency Since Charge (SOC) was blank.

Neither was reachable from a unit test without standing up Home Assistant, so neither was covered.

### What moved

Into `logic.py`, the existing pure/HA-free module:

- `ENERGY_CORRECTION_FIELDS` + `apply_energy_correction(field, value, correction)`
- `odometer_km(basic_status, charging_data, *, factor, saturation)`

`coordinator._extract_odometer_km` and `SAICMGChargingSensor._apply_energy_correction` now delegate, keeping their existing signatures. `_extract_since_charge` and `_extract_pack_energy_kwh` also go through the shared correction rather than open-coding the multiply, so the charge-session maths and the charging sensors can't drift apart.

### Tests

13 new tests in `tests/test_logic.py`:

- the correction applied to both inflated fields, using Harry's real numbers (20.20 kWh → ~6.73 kWh)
- distance fields left alone; no-correction and missing-value passthrough; zero corrected rather than treated as missing
- odometer source preference, `rvsChargeStatus` fallback, saturation fall-through
- an explicit test that `chrgMgmtData` yields no odometer — the exact shape of the original bug

Full suite: 162 tests, same 2 pre-existing unrelated import errors in `test_setup_and_config_flow.py` as on `beta`.

Version stays at `1.2.7-beta5` — beta5 is not yet released, so this rides along with #330.