### PR TITLE
feat(capacity): resolve battery capacity once, with the API as a real third tier

### DIFF
--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -11,7 +11,12 @@ from homeassistant.util.dt import utcnow
 from .api import SAICMGAPIClient, CommandsLimitReachedException
 from .backends import Feature
 from .backends import backend_supports as _backend_supports
-from .logic import apply_energy_correction, odometer_km, select_update_interval
+from .logic import (
+    apply_energy_correction,
+    odometer_km,
+    resolve_battery_capacity,
+    select_update_interval,
+)
 from .trip_stats import TripStatsManager, TripSnapshot, ChargeSnapshot
 
 # After the car turns off, fire extra refreshes at these intervals (seconds)
@@ -1433,7 +1438,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
 
         snap = self._trip_snapshot(basic_status, charging_data)
         trip_kwargs = dict(
-            capacity_kwh=self.known_battery_capacity_kwh,
+            capacity_kwh=self.effective_battery_capacity_kwh,
             tank_litres=self.known_fuel_tank_litres,
             is_electric=self.vehicle_type in ("BEV", "PHEV"),
             is_combustion=self.vehicle_type in ("ICE", "HEV", "PHEV"),
@@ -1477,6 +1482,35 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
                 self._schedule_trip_save()
             elif was_seeded:
                 self._schedule_trip_save()
+
+    @property
+    def battery_capacity_resolution(self):
+        """(capacity_kwh, source) using override > profile > API, or (None, None).
+
+        Every capacity consumer reads this, so the Total Battery Capacity
+        sensor and the energy maths derived from it can no longer disagree
+        about what the pack holds — which they did: the sensor honoured the
+        API tier while the derived figures did not, leaving unprofiled cars
+        with a populated capacity next to three blank sensors (#262, #302).
+        """
+        return resolve_battery_capacity(
+            self.battery_capacity_override,
+            getattr(self, "_profile_battery_capacity_kwh", None),
+            self._api_battery_capacity_raw(),
+            factor=DATA_DECIMAL_CORRECTION,
+        )
+
+    @property
+    def effective_battery_capacity_kwh(self):
+        """Usable capacity in kWh from any tier, or None if nothing is usable."""
+        return self.battery_capacity_resolution[0]
+
+    def _api_battery_capacity_raw(self):
+        """The car's own totalBatteryCapacity, raw and uncorrected, or None."""
+        charging_data = (self.data or {}).get("charging")
+        rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
+        raw = getattr(rcs, "totalBatteryCapacity", None) if rcs is not None else None
+        return raw if raw is not None and raw > 0 else None
 
     def _extract_pack_energy_kwh(self, charging_data):
         """Energy currently held in the pack (kWh), per the car's own figures.
@@ -1536,7 +1570,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         charge, changed = self.trip_stats.note_charge_state(
             status in CHARGE_SESSION_STATUS_CODES,
             self._charge_snapshot(basic_status, charging_data),
-            capacity_kwh=self.known_battery_capacity_kwh,
+            capacity_kwh=self.effective_battery_capacity_kwh,
             now_iso=datetime.now(timezone.utc).isoformat(),
         )
         if charge is not None:

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -143,3 +143,55 @@ def odometer_km(basic_status, charging_data, *, factor, saturation):
         if raw is not None and raw > 0 and raw != saturation:
             return raw * factor
     return None
+
+
+# The API's totalBatteryCapacity is unreliable on several MG series, which is
+# why VEHICLE_PROFILES carries known-good figures. 725 (-> 72.5 kWh with the
+# x0.1 decimal correction) is a documented placeholder rather than a real pack
+# size, seen identically on EC32/AS33P/S12L and others. A car that reports it
+# is far more likely to be emitting the placeholder than to genuinely hold
+# 72.5 kWh — and a car that genuinely does gets its figure from its profile.
+BATTERY_CAPACITY_PLACEHOLDER_RAW = 725
+
+# Sanity bounds for an API-reported capacity, in kWh. Wide on purpose: this
+# only has to reject nonsense (0, negatives, absurd magnitudes), not second
+# guess a plausible pack.
+MIN_PLAUSIBLE_BATTERY_KWH = 5.0
+MAX_PLAUSIBLE_BATTERY_KWH = 200.0
+
+
+def resolve_battery_capacity(
+    override_kwh,
+    profile_kwh,
+    api_raw,
+    *,
+    factor,
+):
+    """Resolve the usable battery capacity and say where it came from.
+
+    Precedence is the one the integration has always documented:
+    user override > our per-model profile > the API's own figure. Returns
+    ``(capacity_kwh, source)`` where source is ``"user_override"``,
+    ``"profile"``, ``"api"``, or ``None`` when nothing usable is available.
+
+    Resolving this in one place matters: the Total Battery Capacity sensor
+    honoured all three tiers, but ``known_battery_capacity_kwh`` — which the
+    charge-session and SOC-efficiency maths read — only ever saw the first
+    two. So an unprofiled car showed a populated capacity sensor next to three
+    blank sensors derived from it (#262, #302).
+
+    The API tier is guarded: the placeholder is rejected, as are values
+    outside a wide plausibility band. A rejected API value yields ``None``,
+    which is honest — better a blank capacity than energy figures confidently
+    derived from a number the car made up.
+    """
+    if override_kwh is not None:
+        return override_kwh, "user_override"
+    if profile_kwh is not None:
+        return profile_kwh, "profile"
+    if api_raw is None or api_raw == BATTERY_CAPACITY_PLACEHOLDER_RAW:
+        return None, None
+    capacity = round(api_raw * factor, 2)
+    if not MIN_PLAUSIBLE_BATTERY_KWH <= capacity <= MAX_PLAUSIBLE_BATTERY_KWH:
+        return None, None
+    return capacity, "api"

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.7"
   ],
-  "version": "1.2.7-beta6"
+  "version": "1.2.7-beta7"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -2321,24 +2321,30 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
         """
         if self._field != "totalBatteryCapacity":
             return None
-        if self.coordinator.battery_capacity_override is not None:
-            source = "user_override"
-        elif self.coordinator.known_battery_capacity_kwh is not None:
-            source = "profile"
-        else:
-            source = "api"
-        return {"capacity_source": source}
+        # Reported, not inferred. This used to guess "profile" from
+        # known_battery_capacity_kwh being set, which would mislabel an
+        # API-derived value the moment that attribute gained an API tier —
+        # the exact confusion this attribute was added to prevent (#301).
+        source = self.coordinator.battery_capacity_resolution[1]
+        return {"capacity_source": source} if source else None
 
     @property
     def native_value(self):
         """Return the state of the sensor."""
         # Total Battery Capacity: prefer coordinator's known-good value when set.
         if self._field == "totalBatteryCapacity":
-            known_capacity = getattr(
-                self.coordinator, "known_battery_capacity_kwh", None
-            )
-            if known_capacity is not None:
-                return known_capacity
+            # Single resolution point (override > profile > API, placeholder
+            # rejected), shared with the energy maths so the two can't
+            # disagree about the pack size.
+            capacity = self.coordinator.effective_battery_capacity_kwh
+            if capacity is not None:
+                self._last_valid_value = capacity
+                return capacity
+            # A poll that carried no charging data can't resolve the API tier;
+            # hold the last good figure rather than blinking to Unknown. A
+            # capacity rejected on its merits never became a last valid value,
+            # so this can't resurrect the placeholder.
+            return self._last_valid_value
 
         try:
             charging_data = getattr(
@@ -3472,7 +3478,7 @@ class SAICMGEfficiencySinceResetSensor(CoordinatorEntity, SensorEntity):
             current_soc,
             baseline.get("odometer_km"),
             current_odometer,
-            self.coordinator.known_battery_capacity_kwh,
+            self.coordinator.effective_battery_capacity_kwh,
         )
 
     @property

--- a/tests/test_india_soc.py
+++ b/tests/test_india_soc.py
@@ -153,8 +153,9 @@ def _load_modules():
             f"{PACKAGE}.backends.india",
             PKG_DIR / "backends" / "india.py",
         )
+        logic = _load(f"{PACKAGE}.logic", PKG_DIR / "logic.py")
         sensor = _load(f"{PACKAGE}.sensor", PKG_DIR / "sensor.py")
-        return backends, india, sensor
+        return backends, india, sensor, logic
     finally:
         for name in LOADED_MODULE_NAMES:
             if name in previous_modules:
@@ -163,7 +164,7 @@ def _load_modules():
                 sys.modules.pop(name, None)
 
 
-BACKENDS, INDIA, SENSOR = _load_modules()
+BACKENDS, INDIA, SENSOR, LOGIC = _load_modules()
 
 
 class IndiaBEVStateOfChargeTests(unittest.TestCase):
@@ -198,6 +199,17 @@ class IndiaBEVStateOfChargeTests(unittest.TestCase):
             supports_charging_current_limit=False,
             supports_target_soc=False,
         )
+        # Mirror the coordinator's central capacity resolution (override >
+        # profile > API, placeholder rejected). These stubs have no profile
+        # and no override, so the API tier is what's under test here.
+        rcs = getattr(charging, "rvsChargeStatus", None) if charging else None
+        api_raw = getattr(rcs, "totalBatteryCapacity", None) if rcs else None
+        resolution = LOGIC.resolve_battery_capacity(None, None, api_raw, factor=0.1)
+        coordinator.battery_capacity_override = None
+        coordinator._profile_battery_capacity_kwh = None
+        coordinator.known_battery_capacity_kwh = resolution[0]
+        coordinator.battery_capacity_resolution = resolution
+        coordinator.effective_battery_capacity_kwh = resolution[0]
         coordinator.backend_supports = lambda feature: BACKENDS.backend_supports(
             backend, feature
         )

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -225,5 +225,59 @@ class OdometerKmTests(unittest.TestCase):
         self.assertIsNone(self._odo(None, None))
 
 
+class ResolveBatteryCapacityTests(unittest.TestCase):
+    """Capacity precedence and the API-tier guards (#262, #302).
+
+    The precedence was always documented as override > profile > API, and the
+    Total Battery Capacity sensor implemented all three — but the attribute
+    the energy maths read only ever saw the first two, so unprofiled cars got
+    a populated capacity sensor next to blank derived sensors.
+    """
+
+    FACTOR = 0.1
+
+    def _resolve(self, override=None, profile=None, api_raw=None):
+        return LOGIC.resolve_battery_capacity(
+            override, profile, api_raw, factor=self.FACTOR
+        )
+
+    def test_user_override_wins_over_everything(self):
+        self.assertEqual(
+            self._resolve(override=23.2, profile=64.0, api_raw=725),
+            (23.2, "user_override"),
+        )
+
+    def test_profile_wins_over_api(self):
+        self.assertEqual(
+            self._resolve(profile=23.2, api_raw=725), (23.2, "profile")
+        )
+
+    def test_falls_back_to_api_when_unprofiled(self):
+        # The gap this closes: an unprofiled car reporting a real capacity.
+        self.assertEqual(self._resolve(api_raw=383), (38.3, "api"))
+
+    def test_rejects_the_placeholder(self):
+        # 725 -> 72.5 kWh is a documented placeholder, not a pack size, and is
+        # plausible enough that a range check alone would let it through.
+        self.assertEqual(self._resolve(api_raw=725), (None, None))
+
+    def test_placeholder_still_overridden_by_profile_and_user(self):
+        self.assertEqual(self._resolve(profile=23.2, api_raw=725)[1], "profile")
+        self.assertEqual(
+            self._resolve(override=24.7, api_raw=725)[1], "user_override"
+        )
+
+    def test_rejects_implausible_magnitudes(self):
+        self.assertEqual(self._resolve(api_raw=1)[0], None)      # 0.1 kWh
+        self.assertEqual(self._resolve(api_raw=50000)[0], None)  # 5000 kWh
+
+    def test_nothing_available_yields_no_source(self):
+        self.assertEqual(self._resolve(), (None, None))
+
+    def test_source_is_reported_not_inferred(self):
+        # An API-derived value must not be labelled "profile".
+        self.assertEqual(self._resolve(api_raw=383)[1], "api")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes the gap raised in #262 / #302: the capacity precedence was only half implemented.

### The gap

Precedence has always been documented as **user override > our profile > the API's `totalBatteryCapacity`**, and the Total Battery Capacity sensor honoured all three tiers — it falls through to the raw API value, and `capacity_source` already had `"api"` in its vocabulary for that case.

But `known_battery_capacity_kwh`, which the charge-session maths, the SOC efficiency sensor and the SOC trip stats all read, only ever saw the first two tiers. So on a car with no profile entry:

- Total Battery Capacity: **populated**, from the API
- Last Charge Energy, Efficiency Since Charge (SOC), the SOC trip figures: **blank**, all derived from that same capacity

India surfaced this when #302 turned on `CHARGING_DATA`, but it was never an India problem — any unprofiled series behaved identically, including the MG5 and ZS EV named in the const comments.

### The change

Capacity is resolved once, in `logic.resolve_battery_capacity`, returning `(capacity_kwh, source)`. All four consumers read it via `coordinator.effective_battery_capacity_kwh` / `battery_capacity_resolution`, so the displayed pack size and the energy figures derived from it can no longer disagree about what the pack holds.

### The API tier is guarded

`725` (→ 72.5 kWh) is a documented placeholder, seen identically on EC32/AS33P/S12L, and it's plausible enough that a range check alone would let it through — so it's rejected by value. Anything outside a wide plausibility band (5–200 kWh) is rejected too. A rejected value yields no capacity rather than a fabricated one.

**This changes what some existing users see.** An unprofiled car emitting the placeholder currently displays 72.5 kWh; it will now display nothing. That's deliberate — it was never a real pack size, and under this PR it would otherwise start feeding energy figures people may act on. A car reporting a genuine capacity gains three working sensors.

### `capacity_source` is now reported, not inferred

It previously guessed `"profile"` from `known_battery_capacity_kwh` being non-None. Once that attribute has an API tier, every API-derived value would have been labelled `"profile"` — the exact confusion #301 added the attribute to prevent. The source is now recorded where the decision is made.

### Testing

8 new tests in `tests/test_logic.py` covering precedence, the placeholder rejection (including that a profile or override still wins over it), magnitude bounds, and that the source is reported accurately.

`tests/test_india_soc.py`'s stub coordinator now models the resolution the way the real coordinator does — it previously relied on a defensive `getattr` that no longer exists. Worth @Dr-Blank knowing about, since it touches his test.

Full suite: 170 tests, same 2 pre-existing `aiohttp` import errors as on `beta`.

Version bumped to `1.2.7-beta7`.