### PR TITLE
fix: NameError on every poll in beta8, and repoint Estimated Range After Charging

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Charging Current
 - Charging Current Limit
 - Charging Power
-- Estimated Range After Charging
+- Estimated Range After Charging *(the range the car expects to reach when the current charge completes)*
 - Target SOC *(read-only mirror of the Target SOC slider — shown only on models where the iSmart app supports it)*
 - Charging Duration
 - Remaining Charging Time

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -13,6 +13,7 @@ from .backends import Feature
 from .backends import backend_supports as _backend_supports
 from .logic import (
     apply_energy_correction,
+    electric_range_km,
     odometer_km,
     resolve_battery_capacity,
     select_update_interval,

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.7"
   ],
-  "version": "1.2.7-beta8"
+  "version": "1.2.7-beta9"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -509,7 +509,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
                         coordinator,
                         entry,
                         "Estimated Range After Charging",
-                        "bmsEstdElecRng",
+                        # Was bmsEstdElecRng, which does not track a projected
+                        # range: on an MGS6 at 57% SOC with 285 km showing and
+                        # an 80% target it reported 761 km — nearly double the
+                        # ~400 km projection, and beyond what the car does on a
+                        # full charge. imcuChrgngEstdElecRng read 410 against a
+                        # 398 km projection on the same car (#262).
+                        "imcuChrgngEstdElecRng",
                         SensorDeviceClass.DISTANCE,
                         UnitOfLength.KILOMETERS,
                         "mdi:map-marker-distance",
@@ -2234,6 +2240,22 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
     # _NOT_CHARGING_ZERO_FIELDS above should return 0 explicitly.
     # V2X_DISCHARGING (13) is deliberately absent — it has live current/voltage data.
     _INACTIVE_CHARGING_STATUSES = frozenset({0, 5})
+
+    # Fields whose companion "V" field says whether the value is live. A
+    # capture taken mid-charge with current flowing showed V=0 on
+    # chrgngRmnngTime while it reported a healthy 300 minutes, so 0 is the
+    # valid state and anything else means don't trust the number (#262).
+    _VALIDITY_GATED_FIELDS = {
+        "imcuChrgngEstdElecRng": "imcuChrgngEstdElecRngV",
+    }
+
+    def _is_invalidated(self, data_source):
+        """True when the car flags this field's value as not live."""
+        flag_field = self._VALIDITY_GATED_FIELDS.get(self._field)
+        if flag_field is None or data_source is None:
+            return False
+        flag = getattr(data_source, flag_field, None)
+        return flag is not None and flag != 0
     def _apply_energy_correction(self, value):
         """Scale an inflated energy field by the profile's correction factor.
 
@@ -2354,6 +2376,10 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
 
             if charging_data:
                 charging_status = getattr(charging_data, "bmsChrgSts", None)
+
+                # --- Car says this value isn't live: hold, don't publish ---
+                if self._is_invalidated(charging_data):
+                    return self._last_valid_value
 
                 # --- Fields that return explicit 0 when not charging ---
                 if self._field in self._NOT_CHARGING_ZERO_FIELDS:


### PR DESCRIPTION
Two fixes. The first is urgent: **1.2.7-beta8 is broken for every BEV and PHEV owner.**

### 1. NameError on every poll

```
File "custom_components/mg_saic/coordinator.py", line 1548, in _charge_snapshot
    range_km=electric_range_km(
NameError: name 'electric_range_km' is not defined
```

`_charge_snapshot` calls `electric_range_km`, but the import was never added. The edit that should have added it was a string replacement written against an import block that didn't yet have the shape it assumed, so it matched nothing and failed silently.

Nothing caught it:

- `py_compile` passes — a missing global is a runtime error, not a syntax one
- the full suite passes — no unit test reaches the coordinator's poll path
- so the branch looked green over an integration that crashes on first update

**Guard added at the level of the mistake.** A CI step running `pyflakes` that fails the build on undefined names. It flags this exact line in under a second and covers every future variant. Unused imports are reported but tolerated so the check stays actionable. *That step is supplied separately in the PR discussion — the token used to push this branch lacks `workflow` scope.*

### 2. Estimated Range After Charging has always been wrong

It reads `bmsEstdElecRng`, which doesn't track a projected range at all. On an MGS6 at 57% SOC showing 285 km with an 80% target, it reported **761 km** — against a ~400 km projection, and more than the car manages from empty.

`imcuChrgngEstdElecRng` on the same car read **410** against a 398 km projection: within 3%. And `imcuVehElecRng` matches the Electric Range sensor exactly, confirming these fields are whole kilometres, as the sensor's existing ×1.0 factor assumes. Both live in `chrgMgmtData`, so this is a field swap with no plumbing change.

Values are now gated on the companion validity flag. A capture taken mid-charge with current flowing showed `V=0` on `chrgngRmnngTime` while it reported a healthy 300 minutes, so 0 is the valid state; a non-zero flag holds the last good reading rather than publishing a stale one.

⚠️ **Evidence is one car.** The 761-vs-410 gap is stark and the projection maths lines up, but a second confirmation would be worth having before this reaches stable — ideally from a PHEV, where the charging fields have behaved differently before.

### Testing

258 tests pass. Note that figure: `test_backends.py` and `test_setup_and_config_flow.py` (74 tests) fail to import unless `mg-ismart-india-client` is installed, which is what CI does and what I previously wasn't — earlier "184 tests, 2 pre-existing errors" reports were running about three-quarters of the suite.

Version bumped to `1.2.7-beta9`.