### PR TITLE
chore(india): bump client to 0.1.8

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.7"
+    "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.8-beta1"
+  "version": "1.2.8-beta2"
 }


### PR DESCRIPTION
The India charging sensors in 1.2.7/1.2.8-beta1 pin client 0.1.7, which requests the charging frame with the normal status message ID and never receives it on a real vehicle.

This bumps the client to 0.1.8. That release uses the dedicated messageID=8 request, keeps normal status and charging polls sequential, and treats secondary-account charging as unavailable without breaking vehicle status. No integration code change is needed.

Also bumps the integration version to 1.2.8-beta2 for the follow-up beta release.

Verified with the published 0.1.8 package: 273 unit tests pass and pyflakes reports no undefined names.
