### PR TITLE
fix(sensor): stop discarding Added Electric Range on models that report it

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Target SOC *(read-only mirror of the Target SOC slider — shown only on models where the iSmart app supports it)*
 - Charging Duration
 - Remaining Charging Time
-- Added Electric Range *(live during a charge session only, and not reported at all by most cars — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
+- Added Electric Range *(the range the last charge added, where the car reports it — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
 - Power Usage Since Last Charge
 - Mileage Since Last Charge
 - Efficiency Since Last Charge *(BEV/PHEV; km/kWh, derived from the two sensors above — see [Trip & efficiency statistics](#trip--efficiency-statistics))*
@@ -184,6 +184,10 @@ The integration derives per-trip and per-charge efficiency from data it already 
 Also in the attributes: `range_added_km` (with `range_start_km` / `range_end_km`), `soc_start_pct`, `soc_end_pct`, `soc_added_pct`, `duration_s`, `average_power_kW`, `method` (which figure was used), and the session's start/end timestamps. A `mg_saic_charge_completed` event fires when a charge finishes, carrying the same data, so you can log or notify on it.
 
 The same figure is also published as its own **Last Charge Range Added** sensor. Prefer that one for dashboards: sensor states are converted to your Home Assistant unit system (so miles on an imperial setup), whereas attribute values never are — the `*_km` attributes below are always kilometres regardless of your settings.
+
+**Added Electric Range** shows the electric range a charge added, taken straight from the car rather than calculated. Support varies by model and there is nothing the integration can do about that: an MG IM5 reports it and keeps the figure between charges, while an MGS6 and an MG HS PHEV report `0` throughout a charge with everything else reporting healthily.
+
+Where the car doesn't populate it the sensor reads unknown rather than `0`, so an absent field no longer looks like a working sensor reporting nothing. If yours shows a value, it is the car's own figure; if you want a number that works regardless of model, use **Last Charge Range Added** instead, which is measured across the charging session.
 
 **Estimated Range After Charging** shows the range you'll have when the current charge finishes. The car usually works this out itself, but some models never do: on an MG HS PHEV the field stays at `0` throughout a charge, as does its discharging equivalent, so that car appears not to compute range estimates at all.
 

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -269,3 +269,19 @@ def project_range_at_target(current_range, soc_pct, target_soc_pct, *, min_soc_p
     if projected < current_range:
         return None
     return projected
+
+
+# Fields where a zero means "the car isn't reporting this", not a real value.
+# A charge that added no range, or a range-after-charging of zero, is not a
+# measurement — it's an absence. Cars differ: an MG IM5 reports a retained
+# chrgngAddedElecRng between charges, while an MGS6 and an HS PHEV report 0
+# throughout (#262, #326). Publishing that 0 makes an absent field look like a
+# working sensor, which is how it went unnoticed for years.
+ZERO_MEANS_UNREPORTED_FIELDS = frozenset(
+    {"chrgngAddedElecRng", "imcuChrgngEstdElecRng"}
+)
+
+
+def is_unreported_zero(field, raw):
+    """True when a falsy reading for this field means 'no data', not zero."""
+    return field in ZERO_MEANS_UNREPORTED_FIELDS and not raw

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.8-beta2"
+  "version": "1.2.8-beta3"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -36,7 +36,7 @@ from .const import (
     CHARGING_VOLTAGE_FACTOR,
     DATA_100_DECIMAL_CORRECTION,
 )
-from .logic import apply_energy_correction
+from .logic import apply_energy_correction, is_unreported_zero
 from .utils import create_device_info
 from .trip_stats import compute_since_charge_efficiency, compute_soc_since_reset_efficiency
 
@@ -2234,7 +2234,11 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
         "bmsChrgOtptCrntReq",
         "chargingDuration",
         "chrgngRmnngTime",
-        "chrgngAddedElecRng",
+        # chrgngAddedElecRng deliberately NOT here. Forcing 0 while idle threw
+        # away a real reading on the MG IM5, which retains the range its last
+        # charge added (188 with V=0, gun disconnected — #326). Cars that don't
+        # populate it report 0, which is handled as "unreported" below rather
+        # than published as a value.
     }
     # Status codes where there is genuinely no charge/discharge activity and the
     # _NOT_CHARGING_ZERO_FIELDS above should return 0 explicitly.
@@ -2247,6 +2251,7 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
     # valid state and anything else means don't trust the number (#262).
     _VALIDITY_GATED_FIELDS = {
         "imcuChrgngEstdElecRng": "imcuChrgngEstdElecRngV",
+        "chrgngAddedElecRng": "chrgngAddedElecRngV",
     }
 
     def _is_invalidated(self, data_source):
@@ -2395,6 +2400,19 @@ class SAICMGChargingSensor(CoordinatorEntity, SensorEntity):
                 # range and SOC the car does report than to display a
                 # confident zero (#262). extra_state_attributes exposes
                 # whether the figure came from the car or from us.
+                # --- Added Electric Range: report what the car holds ---
+                # The IM5 keeps the last charge's added range between
+                # sessions, so this is read whether or not a charge is in
+                # progress. A 0 means the car doesn't populate the field
+                # rather than that a charge added nothing (#326).
+                if self._field == "chrgngAddedElecRng":
+                    raw_value = getattr(charging_data, self._field, None)
+                    if is_unreported_zero(self._field, raw_value):
+                        return None
+                    value = raw_value * (self._factor or 1)
+                    self._last_valid_value = value
+                    return value
+
                 if self._field == "imcuChrgngEstdElecRng":
                     reported = getattr(charging_data, self._field, None)
                     if reported:

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -397,5 +397,28 @@ class ProjectRangeAtTargetTests(unittest.TestCase):
         self.assertEqual(LOGIC.TARGET_SOC_PERCENT_BY_CODE[7], 100)
 
 
+class UnreportedZeroTests(unittest.TestCase):
+    """Zero means "no data" for some fields, not a measurement (#262, #326)."""
+
+    def test_added_range_zero_is_unreported(self):
+        # MGS6 and HS PHEV report 0 throughout a charge.
+        self.assertTrue(LOGIC.is_unreported_zero("chrgngAddedElecRng", 0))
+
+    def test_added_range_value_is_reported(self):
+        # MG IM5 retains its last charge's added range between sessions.
+        self.assertFalse(LOGIC.is_unreported_zero("chrgngAddedElecRng", 188))
+
+    def test_missing_value_counts_as_unreported(self):
+        self.assertTrue(LOGIC.is_unreported_zero("chrgngAddedElecRng", None))
+
+    def test_estimated_range_zero_is_unreported(self):
+        self.assertTrue(LOGIC.is_unreported_zero("imcuChrgngEstdElecRng", 0))
+
+    def test_other_fields_may_legitimately_be_zero(self):
+        # Charging current of 0 is a real reading, not an absence.
+        self.assertFalse(LOGIC.is_unreported_zero("bmsPackCrnt", 0))
+        self.assertFalse(LOGIC.is_unreported_zero("chargingDuration", 0))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Added Electric Range works on the MG IM5. We've been throwing the value away.**

From @tabannis's driving log ([#326](https://github.com/townsmcp/mg-saic-ha/issues/326)):

```
chrgngAddedElecRng   188  (V=0, constant across the session)
bmsChrgSts           0    (not charging, gun disconnected)
```

The car populates the field, flags it valid, and **retains the last charge's added range between sessions** — which is exactly what the sensor's name promises, and what was expected of it all along.

The integration never displayed it. `chrgngAddedElecRng` was in `_NOT_CHARGING_ZERO_FIELDS`, so whenever charging status was inactive the sensor returned a hard `0` without reading the field at all.

That also corrects the 1.2.7 release note claiming this sensor "reads 0 on every car we can check". True of the MGS6 and the HS PHEV, which genuinely report 0 mid-charge. Not true of the IM5, where we were the ones zeroing it.

## Changes

- Removed from `_NOT_CHARGING_ZERO_FIELDS` — read whether or not a charge is in progress.
- Added to `_VALIDITY_GATED_FIELDS`, so a non-zero `chrgngAddedElecRngV` holds the last good reading.
- A falsy reading is treated as **not reported** and shows unknown, rather than being published as `0`. Same rule applied to `imcuChrgngEstdElecRng` in #337 — publishing that zero is precisely what let an absent field pass as a working sensor for years.

## ⚠️ Scale is unverified

The sensor keeps its existing `DATA_DECIMAL_CORRECTION` factor, so the IM5's `188` displays as **18.8 km**.

That may be wrong. The neighbouring `imcu*` range fields in the same `chrgMgmtData` block are whole kilometres (`imcuVehElecRng=292` matches `rvsChargeStatus.fuelRangeElec=2920` exactly), so `188` could well be 188 km. 18.8 km is a small but plausible top-up; 188 km is a plausible full charge.

I haven't changed it on a hunch. It needs an owner comparing the sensor against what the car displayed after a known charge. @tabannis is best placed — asked on #326.

## Testing

5 new tests in `tests/test_logic.py` for the unreported-zero rule. 278 pass, pyflakes clean.

Version bumped to `1.2.8-beta3`. README updated: the sensor is now described as model-dependent, pointing at **Last Charge Range Added** for a figure that works regardless.