### PR TITLE
fix: don't treat a clock-skew 403 as a credential rejection (#340)

### DIFF
--- a/custom_components/mg_saic/__init__.py
+++ b/custom_components/mg_saic/__init__.py
@@ -107,6 +107,35 @@ _AUTH_FAILURE_MARKERS = (
 )
 
 
+# SAIC returns HTTP 403 when the client clock is too far out for its signed
+# requests, with an explicit message about the device time (issue #340). That
+# is a transient host problem, not a credential problem: once NTP corrects the
+# clock the same password works again. Matching the server text is fragile —
+# wording may vary by locale or change without notice — so several phrasings
+# are accepted, and an unmatched variant simply falls back to today's
+# behaviour rather than breaking login.
+_CLOCK_SKEW_MARKERS = (
+    "time setting is incorrect",
+    "device's time",
+    "device time",
+    "adjust your device time",
+    "clock skew",
+)
+
+
+def _is_clock_skew(exc: BaseException) -> bool:
+    """True when a rejection is about the host clock rather than credentials.
+
+    Checked before the 403 rule in _is_auth_failure, which would otherwise
+    classify this as a bad password and send the user into a re-auth flow that
+    cannot fix it — the password is correct, and re-entering it changes
+    nothing. It also stops Home Assistant retrying, when retrying is exactly
+    what recovers this once the clock is corrected.
+    """
+    message = str(getattr(exc, "message", None) or exc).lower()
+    return any(marker in message for marker in _CLOCK_SKEW_MARKERS)
+
+
 def _is_auth_failure(exc: BaseException) -> bool:
     """Classify a login exception as a credential failure (vs. transient).
 
@@ -116,6 +145,11 @@ def _is_auth_failure(exc: BaseException) -> bool:
     problems (network errors, HTTP 500, SAIC "code 4", rate limits) return
     False and remain ConfigEntryNotReady so Home Assistant keeps retrying.
     """
+    # A clock-skew 403 is not a credential failure, and must be tested first:
+    # the 401/403 rules below would otherwise claim it (issue #340).
+    if _is_clock_skew(exc):
+        return False
+
     # The global SAIC client raises SaicLogoutException specifically on a
     # 401/403 from the token endpoint.
     if isinstance(exc, SaicLogoutException):
@@ -231,6 +265,15 @@ async def _async_setup_entry_impl(hass: HomeAssistant, entry: ConfigEntry) -> bo
                 # new password in place (issue #250) instead of retrying the
                 # stale one forever.  Transient failures stay ConfigEntryNotReady
                 # and are retried automatically as before.
+                if _is_clock_skew(exc):
+                    LOGGER.error(
+                        "MG SAIC rejected the request because this machine's "
+                        "clock is wrong. The stored credentials are fine — "
+                        "check that time synchronisation (NTP) is running and "
+                        "healthy on the Home Assistant host. Home Assistant "
+                        "will keep retrying and should recover on its own once "
+                        "the clock is correct."
+                    )
                 if _is_auth_failure(exc):
                     raise ConfigEntryAuthFailed(
                         "MG SAIC rejected the stored credentials; please "

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.8-beta3"
+  "version": "1.2.8-beta4"
 }

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -687,6 +687,55 @@ class TestAuthFailureClassifier(unittest.TestCase):
         self.assertFalse(SETUP._is_auth_failure(Exception("Connection timed out")))
 
 
+class TestClockSkewClassifier(unittest.TestCase):
+    """A clock-skew 403 must not be mistaken for a bad password (issue #340).
+
+    SAIC rejects signed requests when the host clock has drifted, using HTTP
+    403 — the same status as a credential rejection. Treating it as one sends
+    the user into a re-auth flow that cannot help (the password is correct)
+    and stops the retries that would otherwise recover once NTP corrects.
+    """
+
+    SAIC_MESSAGE = (
+        "return code: 403, message: {\"code\":403,\"message\":\"Your device's "
+        "time setting is incorrect, which prevents the operation from being "
+        "completed. Please adjust your device time to the correct settings "
+        "and try again.\"}"
+    )
+
+    def test_reported_message_is_recognised(self):
+        self.assertTrue(SETUP._is_clock_skew(Exception(self.SAIC_MESSAGE)))
+
+    def test_clock_skew_is_not_an_auth_failure(self):
+        self.assertFalse(SETUP._is_auth_failure(Exception(self.SAIC_MESSAGE)))
+
+    def test_clock_skew_wins_over_the_403_status_rule(self):
+        # The status-code rule alone would classify this as a credential
+        # failure; the skew check must be tested first.
+        exc = Exception(self.SAIC_MESSAGE)
+        exc.status_code = 403
+        self.assertFalse(SETUP._is_auth_failure(exc))
+
+    def test_shorter_phrasings_are_recognised(self):
+        for text in (
+            "Your device time is wrong",
+            "Please adjust your device time",
+            "clock skew detected",
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(SETUP._is_clock_skew(Exception(text)))
+
+    def test_genuine_credential_failure_is_unaffected(self):
+        exc = Exception("please check your credentials")
+        self.assertFalse(SETUP._is_clock_skew(exc))
+        self.assertTrue(SETUP._is_auth_failure(exc))
+
+    def test_unrelated_403_is_still_an_auth_failure(self):
+        exc = Exception("forbidden")
+        exc.status_code = 403
+        self.assertTrue(SETUP._is_auth_failure(exc))
+
+
 class TestSetupAuthVsTransient(unittest.TestCase):
     """async_setup_entry raises the right exception so HA either prompts for
     new credentials (auth) or keeps retrying quietly (transient)."""


### PR DESCRIPTION
@Hattuma's report ([#340](https://github.com/townsmcp/mg-saic-ha/issues/340)): a 403 about the host clock is being reported to the user as a rejected password.

```
Error fetching vehicle data: return code: 403, message: {"code":403,
"message":"Your device's time setting is incorrect, which prevents the
operation from being completed. Please adjust your device time..."}
```

followed a few minutes later by:

> Config entry ... could not authenticate: MG SAIC rejected the stored credentials; please re-enter your password.

### Two bugs, not one

**The message is wrong.** `_is_auth_failure` treats *any* 403 as a credential rejection. SAIC uses 403 for clock skew on its signed requests, so the user is told to re-enter a password that is already correct, into a re-auth flow that cannot fix a clock.

**The recovery behaviour is wrong.** `ConfigEntryAuthFailed` stops the retry loop and waits for the user. Clock skew is transient — once NTP corrects, the same credentials work. `ConfigEntryNotReady` and the normal retry loop would have healed this unattended. The reporter has been restarting chrony and reloading both entries by hand to get back something that would have returned on its own.

### Change

`_is_clock_skew` is checked **before** the 401/403 rules in `_is_auth_failure`, which would otherwise claim the exception first. A match returns transient, and logs an error stating the credentials are fine and pointing at time synchronisation on the host.

Matching on server text is fragile — wording may vary by locale or change without notice — so several phrasings are accepted, and an unrecognised variant falls through to existing behaviour rather than breaking login. The raw message is already logged at debug, so a future variant stays diagnosable.

### What this does not do

It can't fix the clock, and it can't detect skew before a request: HA exposes no clock-health signal, and the SAIC client doesn't surface the server's `Date` header, which is the only sane way to measure drift. The user still needs working NTP — they just won't be told their password is wrong, and the integration recovers by itself once the clock is right.

### Testing

6 new tests in `tests/test_setup_and_config_flow.py`, including the exact message from the issue, that skew beats the 403 status rule, and that genuine credential failures and unrelated 403s are unaffected. 284 pass, pyflakes clean.

Version bumped to `1.2.8-beta4`.