### PR TITLE
fix(sensor): Added Electric Range is whole km, not tenths (#326)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Also in the attributes: `range_added_km` (with `range_start_km` / `range_end_km`
 
 The same figure is also published as its own **Last Charge Range Added** sensor. Prefer that one for dashboards: sensor states are converted to your Home Assistant unit system (so miles on an imperial setup), whereas attribute values never are — the `*_km` attributes below are always kilometres regardless of your settings.
 
-**Added Electric Range** shows the electric range a charge added, taken straight from the car rather than calculated. Support varies by model and there is nothing the integration can do about that: an MG IM5 reports it and keeps the figure between charges, while an MGS6 and an MG HS PHEV report `0` throughout a charge with everything else reporting healthily.
+**Added Electric Range** shows the electric range a charge added, in kilometres as the car reports it, taken straight from the car rather than calculated. Support varies by model and there is nothing the integration can do about that: an MG IM5 reports it and keeps the figure between charges, while an MGS6 and an MG HS PHEV report `0` throughout a charge with everything else reporting healthily.
 
 Where the car doesn't populate it the sensor reads unknown rather than `0`, so an absent field no longer looks like a working sensor reporting nothing. If yours shows a value, it is the car's own figure; if you want a number that works regardless of model, use **Last Charge Range Added** instead, which is measured across the charging session.
 

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -416,7 +416,15 @@ async def async_setup_entry(hass, entry, async_add_entities):
                         UnitOfLength.KILOMETERS,
                         "mdi:map-marker-distance",
                         "measurement",
-                        DATA_DECIMAL_CORRECTION,
+                        # Whole km, not tenths. @tabannis confirmed his IM5's
+                        # 188 was 188 km from an overnight charge, not 18.8
+                        # (#326). Consistent with the rest of chrgMgmtData:
+                        # imcuVehElecRng and clstrElecRngToEPT are whole km
+                        # there, while the tenths-scaled fuelRangeElec lives
+                        # in rvsChargeStatus. The old x0.1 was inherited from
+                        # the surrounding fields and never verified, because
+                        # every car we could check reported 0.
+                        1.0,
                         "chrgMgmtData",
                         "charging",
                     ),

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -420,5 +420,35 @@ class UnreportedZeroTests(unittest.TestCase):
         self.assertFalse(LOGIC.is_unreported_zero("chargingDuration", 0))
 
 
+class AddedElectricRangeScaleTests(unittest.TestCase):
+    """Added Electric Range is whole km, not tenths (#326).
+
+    Guards a value that was wrong for years without anyone noticing, because
+    every car we could check reported 0 and 0 is the same at either scale.
+    @tabannis confirmed his IM5's raw 188 was 188 km after an overnight
+    charge, not 18.8.
+    """
+
+    def test_sensor_registers_whole_km_factor(self):
+        import re
+        import pathlib
+
+        src = pathlib.Path(
+            __file__
+        ).resolve().parent.parent.joinpath(
+            "custom_components/mg_saic/sensor.py"
+        ).read_text()
+        block = re.search(
+            r'"Added Electric Range",.*?\n\s*"chrgMgmtData"', src, re.S
+        )
+        self.assertIsNotNone(block, "Added Electric Range registration not found")
+        self.assertNotIn(
+            "DATA_DECIMAL_CORRECTION",
+            block.group(0),
+            "Added Electric Range must not use the tenths correction — the car "
+            "reports whole kilometres (#326)",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@tabannis confirmed the scale question left open in #341:

> It'll be 188km for range added for sure, my last charge before that log dump was a big overnight fill up

So `chrgngAddedElecRng` is **whole kilometres**, not tenths. The sensor was displaying his 188 km charge as 18.8 km. Factor dropped from `DATA_DECIMAL_CORRECTION` to `1.0`.

### Why it was wrong

The `×0.1` was inherited from the fields around it and never verified — because **every car we could check reported 0**, and 0 is the same at either scale. Nothing could contradict it until a car turned up that actually populates the field.

Whole km is also consistent with the block it lives in: `imcuVehElecRng` and `clstrElecRngToEPT` are whole km in `chrgMgmtData`, while the tenths-scaled `fuelRangeElec` sits in `rvsChargeStatus`.

### Scope

Only affects models that populate the field — currently just the IM5. Everywhere else it reads 0, which #341 now surfaces as unknown regardless of scale.

### Testing

A test asserts the registration doesn't use the decimal correction, so this can't quietly drift back. 284 pass, pyflakes clean.

**No version bump** — `beta` is already at `1.2.8-beta4` and unreleased, so this ships alongside #342 whenever the next release goes out.