### PR TITLE
fix: rebase the SOC baseline from the low point, drop an invalid state_class

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.8-beta4"
+  "version": "1.2.8-beta5"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3451,9 +3451,13 @@ class SAICMGLastChargeEnergySensor(CoordinatorEntity, SensorEntity):
         self._attr_icon = "mdi:battery-charging-medium"
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-        # "measurement", not total_increasing: this is a per-session figure
-        # that goes up and down with each charge, not a running total.
-        self._attr_state_class = "measurement"
+        # No state_class. Home Assistant only accepts total/total_increasing
+        # alongside device_class energy, and neither describes this: it is a
+        # per-charge figure that jumps to an unrelated value each session
+        # rather than accumulating. "measurement" was invalid and logged a
+        # warning; declaring a total here would instead feed nonsense into
+        # long-term statistics, which is worse than having none.
+        self._attr_state_class = None
         vin_info = coordinator.vin_info
         self._unique_id = f"{entry.entry_id}_{vin_info.vin}_last_charge_energy"
         self._device_info = create_device_info(coordinator, entry.entry_id)

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -41,6 +41,11 @@ from dataclasses import dataclass, asdict
 from datetime import datetime
 from typing import Any
 
+# Minimum SOC rise (%) above the lowest point seen since the baseline was set
+# for the car to be considered charging. Above the post-drive pack rebound
+# (typically 0.1-0.4%), below any charge worth rebasing on.
+SOC_CHARGE_RISE_PCT = 0.5
+
 # Minimum SOC rise (%) for a plugged-in period to be recorded as a charge.
 # Filters out a plug-in that delivered nothing and the small SOC rebound the
 # pack reports after a drive.
@@ -716,16 +721,44 @@ class TripStatsManager:
         """
         if soc_pct is None or odometer_km is None:
             return False
-        if self.soc_reset_baseline is None or soc_pct > self.soc_reset_baseline.get(
-            "soc_pct", -1.0
-        ):
-            self.soc_reset_baseline = {
-                "soc_pct": round(soc_pct, 1),
-                "odometer_km": round(odometer_km, 3),
-                "ts": ts,
-            }
+
+        if self.soc_reset_baseline is None:
+            self.soc_reset_baseline = self._new_soc_baseline(soc_pct, odometer_km, ts)
+            return True
+
+        # Rebase on a rise above the LOWEST SOC seen since the baseline was
+        # set, not above the baseline itself. The old rule kept a running
+        # maximum, so a charge that stopped below a previous peak never
+        # rebased: an 80% baseline, 192 km of driving, then a charge back to
+        # 79.3% left the odometer baseline 192 km stale while SOC looked
+        # almost untouched — 0.7% "used" over 192 km, and an efficiency figure
+        # two orders of magnitude too high.
+        #
+        # Measuring from the low point also catches a slow trickle charge,
+        # where no single poll rises far enough to trip the threshold on its
+        # own but the total gain does.
+        low = self.soc_reset_baseline.get(
+            "soc_low_pct", self.soc_reset_baseline.get("soc_pct", soc_pct)
+        )
+        if soc_pct >= low + SOC_CHARGE_RISE_PCT:
+            self.soc_reset_baseline = self._new_soc_baseline(soc_pct, odometer_km, ts)
+            return True
+
+        # Still discharging: track the new low so the next charge is measured
+        # from the bottom of this cycle.
+        if soc_pct < low:
+            self.soc_reset_baseline["soc_low_pct"] = round(soc_pct, 1)
             return True
         return False
+
+    @staticmethod
+    def _new_soc_baseline(soc_pct, odometer_km, ts) -> dict[str, Any]:
+        return {
+            "soc_pct": round(soc_pct, 1),
+            "odometer_km": round(odometer_km, 3),
+            "ts": ts,
+            "soc_low_pct": round(soc_pct, 1),
+        }
 
     def note_charge_state(
         self,

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -429,13 +429,60 @@ class TestNoteSocResetBaseline(unittest.TestCase):
     def test_rebases_on_soc_rise_only(self):
         m = self._mgr()
         m.note_soc_reset_baseline(50.0, 1000.0, "t1")
-        # SOC dropped (driving happened) -> no rebase.
-        self.assertFalse(m.note_soc_reset_baseline(40.0, 1010.0, "t2"))
+        # SOC dropped (driving happened) -> baseline unchanged. The call still
+        # reports a change, because the new low must be persisted.
+        m.note_soc_reset_baseline(40.0, 1010.0, "t2")
         self.assertEqual(m.soc_reset_baseline["soc_pct"], 50.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 1000.0)
         # SOC rose (a charge) -> rebase.
         self.assertTrue(m.note_soc_reset_baseline(100.0, 1010.0, "t3"))
         self.assertEqual(m.soc_reset_baseline["soc_pct"], 100.0)
         self.assertEqual(m.soc_reset_baseline["odometer_km"], 1010.0)
+
+    def test_rebases_on_a_charge_that_stops_below_the_previous_peak(self):
+        """The bug this replaced: the old rule kept a running maximum, so a
+        charge ending below a previous peak never rebased. Real numbers from
+        an MGS6 — 80% baseline, 192 km driven, charged back to 79.3%, leaving
+        0.7% "used" over 192 km and an efficiency two orders of magnitude out.
+        """
+        m = self._mgr()
+        m.note_soc_reset_baseline(80.0, 4000.0, "t1")
+        m.note_soc_reset_baseline(21.0, 4192.0, "t2")  # driven 192 km
+        m.note_soc_reset_baseline(79.3, 4192.0, "t3")  # charged, below 80
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 79.3)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 4192.0)
+
+    def test_post_drive_rebound_does_not_rebase(self):
+        # The pack reports a fraction of a percent back after parking. That is
+        # not a charge and must not move the baseline.
+        m = self._mgr()
+        m.note_soc_reset_baseline(80.0, 1000.0, "t1")
+        m.note_soc_reset_baseline(60.0, 1100.0, "t2")
+        m.note_soc_reset_baseline(60.3, 1100.0, "t3")
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 80.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 1000.0)
+
+    def test_slow_trickle_charge_is_caught_cumulatively(self):
+        # No single step clears the threshold, but the total gain does.
+        m = self._mgr()
+        m.note_soc_reset_baseline(80.0, 1000.0, "t1")
+        m.note_soc_reset_baseline(60.0, 1100.0, "t2")
+        for soc in (60.2, 60.4, 60.6):
+            m.note_soc_reset_baseline(soc, 1100.0, "t")
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 60.6)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 1100.0)
+
+    def test_low_water_mark_follows_the_discharge(self):
+        m = self._mgr()
+        m.note_soc_reset_baseline(80.0, 1000.0, "t1")
+        for soc, odo in ((70.0, 1050.0), (55.0, 1120.0), (30.0, 1240.0)):
+            m.note_soc_reset_baseline(soc, odo, "t")
+        self.assertEqual(m.soc_reset_baseline["soc_low_pct"], 30.0)
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 80.0)
+        # A charge from the bottom rebases to where the charge ended.
+        m.note_soc_reset_baseline(45.0, 1240.0, "t")
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 45.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 1240.0)
 
     def test_none_soc_is_a_no_op(self):
         m = self._mgr()


### PR DESCRIPTION
Two unrelated fixes found in a Home Assistant audit and a dashboard check.

## 1. Efficiency Since Charge (SOC) reporting absurd figures

An MGS6 showing **229 mi/kWh**. Its own attributes give it away:

```
distance_km        192.0
soc_used_pct       0.7
baseline_soc_pct   80.0     (car currently at 79.3%)
energy_kWh         0.52
```

192 km driven against 0.7% of battery used.

`note_soc_reset_baseline` rebased only when SOC rose **above the baseline**, i.e. it tracked a running maximum. A charge that stopped below a previous peak never rebased at all: an 80% baseline, 192 km of driving, then a charge back to 79.3% — below 80, so no rebase — left the odometer baseline 192 km stale while SOC looked almost untouched.

This is long-standing; the extraction bug fixed in 1.2.7-beta5 had been masking it by keeping the sensor permanently `Unknown`.

**Fix:** rebase on a rise above the **lowest SOC seen since the baseline was set**, tracked as `soc_low_pct`. That catches any charge wherever it stops, and also catches a slow trickle where no single poll clears the threshold but the cumulative gain does. The 0.5% floor still ignores the fraction of a percent the pack reports back after parking.

Note the return contract changed slightly: a SOC *drop* now returns `True`, because the new low needs persisting. The caller already treats the return as "state changed, save it", so no behaviour change there.

## 2. Invalid `state_class` on Last Charge Energy

`state_class: measurement` with `device_class: energy` is rejected by Home Assistant — it accepts only `total` or `total_increasing` there — and logs a warning.

Neither total describes this sensor: it's a per-charge figure that jumps to an unrelated value each session rather than accumulating. So the `state_class` is **dropped** rather than swapped. Declaring a total would feed nonsense into long-term statistics, which is worse than having none.

Last Charge Range Added is unaffected: `distance` isn't a restricted device class.

## Testing

5 new tests, including the exact reported numbers, plus post-drive rebound, trickle charge, and low-water-mark tracking. 289 pass, pyflakes clean.

**No version bump** — `beta` is at `1.2.8-beta4` and unreleased, so this ships with #342 and #343.