### PR TITLE
feat(india): expose pack energy, charge counters and remaining time

### DIFF
--- a/custom_components/mg_saic/backends/india.py
+++ b/custom_components/mg_saic/backends/india.py
@@ -104,6 +104,26 @@ def _charging_duration_units(seconds: int | None) -> int | None:
     )
 
 
+def _last_charge_ending_power(charge) -> int | None:
+    """What the pack held when the last charge ended, in tenths of a kWh.
+
+    The India frame has a ``lastChargeEndingPower`` field, but it mirrors live
+    pack energy rather than reporting the last charge's ending energy, so the
+    client decodes it as sent and leaves the interpretation here. Adding back
+    the energy drawn since that charge recovers the real figure, which is what
+    the global ``ending - powerUsageSinceLastCharge`` identity expects.
+
+    :param charge: a :class:`~mg_ismart_india_client.models.ChargeStatus`.
+    :returns: the value for ``rvsChargeStatus.lastChargeEndingPower``, or
+        ``None`` when either term is missing.
+    """
+    energy = _tenths(charge.battery_energy_kwh)
+    used = _tenths(charge.power_usage_since_last_charge_kwh)
+    if energy is None or used is None:
+        return None
+    return energy + used
+
+
 def _micro_degrees(value: float | None) -> int | None:
     if value is None:
         return None
@@ -417,6 +437,17 @@ class IndiaBackend:
         field, so every value the sensors read has a named source and a stated
         scale assumption.
 
+        Pack energy also goes out as ``packEnergyKwh``, in real kWh, so the
+        coordinator can take it without applying scales it never went through.
+        ``lastChargeEndingPower`` is reconstructed here (see
+        :func:`_last_charge_ending_power`) rather than passed through, because
+        the India frame's field of that name reports live pack energy and would
+        break the global ``ending - powerUsageSinceLastCharge`` identity.
+
+        ``startTime`` and ``endTime`` are not mapped: ``endTime`` is not a real
+        estimate, and there is no charge-start entity for ``startTime`` to
+        feed.
+
         The preceding status refresh requests both frames from the shared TAP
         stream and stores the charging frame here. This method only maps that
         result; it must not start a second poll.
@@ -443,6 +474,8 @@ class IndiaBackend:
             ),
             bmsPackSOCDsp=_tenths(charge.soc),
             bmsChrgSts=bms_chrg_sts,
+            # Already minutes, which is what the sensor's 1.0 factor expects.
+            chrgngRmnngTime=charge.charge_time_remaining_min,
         )
         rvs = _ns(
             # Range and odometer come back in real units and re-encode to tenths.
@@ -452,6 +485,12 @@ class IndiaBackend:
             chargingDuration=_charging_duration_units(charge.charge_time_elapsed_s),
             totalBatteryCapacity=_tenths(charge.total_battery_capacity_kwh),
             mileageSinceLastCharge=_tenths(charge.distance_since_last_charge_km),
+            # Real kWh, so the coordinator takes it without rescaling.
+            packEnergyKwh=charge.battery_energy_kwh,
+            powerUsageSinceLastCharge=_tenths(
+                charge.power_usage_since_last_charge_kwh
+            ),
+            lastChargeEndingPower=_last_charge_ending_power(charge),
         )
         return _ns(chrgMgmtData=chrg_mgmt, rvsChargeStatus=rvs)
 

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -1548,11 +1548,19 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
     def _extract_pack_energy_kwh(self, charging_data):
         """Energy currently held in the pack (kWh), per the car's own figures.
 
-        ``lastChargeEndingPower`` is what the pack held when the last charge
-        finished; ``powerUsageSinceLastCharge`` is what has been taken out
-        since. The difference is therefore the energy in the pack right now,
-        and it holds at both charge boundaries — at the end of a charge the
-        since-charge counter is ~0, so it collapses to lastChargeEndingPower.
+        A backend that reports pack energy outright, in real kWh, wins:
+        ``packEnergyKwh`` is taken as-is, with no decimal or per-model energy
+        correction, because it never went through the global raw scales those
+        corrections exist to undo. India reports it; without it Last
+        Charge Energy stayed blank on every India car, since the reconstruction
+        below has nothing to work with there.
+
+        Otherwise it is reconstructed. ``lastChargeEndingPower`` is what the
+        pack held when the last charge finished; ``powerUsageSinceLastCharge``
+        is what has been taken out since. The difference is therefore the
+        energy in the pack right now, and it holds at both charge boundaries —
+        at the end of a charge the since-charge counter is ~0, so it collapses
+        to lastChargeEndingPower.
 
         Both fields are inflated ~3× on some models, so both get the profile's
         charging_capacity_correction (#262). Returns None if either is missing.
@@ -1560,6 +1568,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         rcs = getattr(charging_data, "rvsChargeStatus", None) if charging_data else None
         if rcs is None:
             return None
+        direct = getattr(rcs, "packEnergyKwh", None)
+        if direct is not None and direct >= 0:
+            return float(direct)
         raw = getattr(rcs, "lastChargeEndingPower", None)
         if raw is None or raw < 0:
             return None

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -13,7 +13,7 @@
     "requests",
     "pycryptodome",
     "mg-saic-client==0.9.4",
-    "mg-ismart-india-client==0.1.8"
+    "mg-ismart-india-client==0.2.0"
   ],
   "version": "1.2.8-beta5"
 }

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -331,15 +331,67 @@ class TestIndiaBackendAdapter(unittest.TestCase):
         self.assertEqual(charging.chrgMgmtData.bmsPackCrnt, 19680)
         self.assertEqual(charging.chrgMgmtData.bmsPackSOCDsp, 625)
         self.assertEqual(charging.chrgMgmtData.bmsChrgSts, 3)
+        # Already minutes, so the sensor's 1.0 factor leaves it alone.
+        self.assertEqual(charging.chrgMgmtData.chrgngRmnngTime, 186)
         self.assertEqual(charging.rvsChargeStatus.fuelRangeElec, 852)
         self.assertEqual(charging.rvsChargeStatus.mileage, 12345)
         self.assertEqual(charging.rvsChargeStatus.chargingDuration, 150)
         self.assertEqual(charging.rvsChargeStatus.totalBatteryCapacity, 508)
         self.assertEqual(charging.rvsChargeStatus.mileageSinceLastCharge, 456)
-        self.assertFalse(
-            hasattr(charging.rvsChargeStatus, "powerUsageSinceLastCharge")
+        # Real kWh, taken as-is rather than reconstructed (#302).
+        self.assertEqual(charging.rvsChargeStatus.packEnergyKwh, 31.75)
+        # Both energy counters re-encode from kWh onto the global tenths scale.
+        self.assertEqual(charging.rvsChargeStatus.powerUsageSinceLastCharge, 40)
+        self.assertEqual(charging.rvsChargeStatus.lastChargeEndingPower, 358)
+        # ...and the global identity turns that pair back into the pack energy.
+        self.assertEqual(
+            charging.rvsChargeStatus.lastChargeEndingPower
+            - charging.rvsChargeStatus.powerUsageSinceLastCharge,
+            318,
         )
         self.assertIsNone(_run(self.backend.get_charging_info("VIN1")))
+
+    def test_idle_car_reports_no_remaining_charging_time(self):
+        """The client resolves the frame's idle sentinel to None, so a parked
+        car must report nothing rather than a sentinel-sized duration."""
+        self.fake.charge.charge_time_remaining_min = None
+        _run(self.backend.get_vehicle_status("VIN1"))
+        charging = _run(self.backend.get_charging_info("VIN1"))
+
+        self.assertIsNone(charging.chrgMgmtData.chrgngRmnngTime)
+
+    def test_since_charge_counter_is_withheld_not_guessed(self):
+        """The counter is OPTIONAL in the ASN.1. Without it the reconstruction
+        has no second term, so both sensors must go blank rather than show a
+        fabricated figure — but pack energy does not depend on it."""
+        self.fake.charge.power_usage_since_last_charge_kwh = None
+        _run(self.backend.get_vehicle_status("VIN1"))
+        charging = _run(self.backend.get_charging_info("VIN1"))
+
+        self.assertIsNone(charging.rvsChargeStatus.lastChargeEndingPower)
+        self.assertIsNone(charging.rvsChargeStatus.powerUsageSinceLastCharge)
+        self.assertEqual(charging.rvsChargeStatus.packEnergyKwh, 31.75)
+
+    def test_ending_power_holds_steady_as_the_pack_drains(self):
+        """The ending power is a property of the last charge, so it must not
+        drift while the car is driven: the reconstruction trades pack energy
+        against the since-charge counter one-for-one."""
+        for energy, used in ((37.3, 0.0), (29.8, 7.5), (29.6, 7.7)):
+            with self.subTest(energy=energy):
+                self.fake.charge.battery_energy_kwh = energy
+                self.fake.charge.power_usage_since_last_charge_kwh = used
+                _run(self.backend.get_vehicle_status("VIN1"))
+                charging = _run(self.backend.get_charging_info("VIN1"))
+                self.assertEqual(
+                    charging.rvsChargeStatus.lastChargeEndingPower, 373
+                )
+
+    def test_pack_energy_survives_a_frame_with_no_soc(self):
+        self.fake.charge.soc = None
+        _run(self.backend.get_vehicle_status("VIN1"))
+        charging = _run(self.backend.get_charging_info("VIN1"))
+
+        self.assertEqual(charging.rvsChargeStatus.packEnergyKwh, 31.75)
 
     def test_non_electric_status_does_not_wait_for_charge(self):
         self.backend._electric_vins.clear()
@@ -398,6 +450,9 @@ class FakeIndiaClient:
             charge_time_elapsed_s=90,
             total_battery_capacity_kwh=50.8,
             distance_since_last_charge_km=45.6,
+            battery_energy_kwh=31.75,
+            power_usage_since_last_charge_kwh=4.0,
+            charge_time_remaining_min=186,
         )
 
     async def login(self):

--- a/tests/test_india_client_contract.py
+++ b/tests/test_india_client_contract.py
@@ -1,0 +1,206 @@
+# File: tests/test_india_client_contract.py
+#
+# Contract check between the India backend adapter and the *released*
+# mg-ismart-india-client pinned in manifest.json.
+#
+# Every other India test drives the adapter through a hand-written fake
+# client, so an attribute the adapter reads but the pinned release does not
+# provide passes CI unnoticed.  That is exactly how the 0.1.8 pin survived
+# next to accesses to charge_time_remaining_min and
+# power_usage_since_last_charge_kwh, neither of which exists in that release:
+# the fake supplied them, and a real charging response would have raised
+# AttributeError on the first poll.
+#
+# So this file deliberately does NOT stub mg_ismart_india_client.  It builds a
+# real ChargeStatus from whatever release is installed and runs the adapter
+# over it, so a pin that lags the attributes the adapter needs fails loudly.
+# The python-tests.yaml workflow installs the client straight from the
+# manifest pin, so what CI checks is the pin itself.  Locally the client may
+# be absent, in which case these tests skip.
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+
+# find_spec looks at the filesystem, so a MagicMock another test module left
+# in sys.modules cannot make an absent client look installed.
+CLIENT_INSTALLED = importlib.util.find_spec("mg_ismart_india_client") is not None
+
+
+def _stub(name):
+    if name in sys.modules:
+        return
+    try:
+        __import__(name)
+    except ImportError:
+        sys.modules[name] = MagicMock()
+
+
+def _load(name, path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+if CLIENT_INSTALLED:
+    for _name in (
+        "saic_ismart_client_ng",
+        "saic_ismart_client_ng.model",
+        "saic_ismart_client_ng.api",
+        "saic_ismart_client_ng.api.vehicle_charging",
+        "voluptuous",
+        "homeassistant",
+        "homeassistant.helpers",
+        "homeassistant.helpers.config_validation",
+    ):
+        _stub(_name)
+
+    if "mg_saic" not in sys.modules:
+        _pkg = types.ModuleType("mg_saic")
+        _pkg.__path__ = [str(PKG_DIR)]
+        sys.modules["mg_saic"] = _pkg
+
+    _load("mg_saic.const", PKG_DIR / "const.py")
+    _load("mg_saic.logic", PKG_DIR / "logic.py")
+    _load("mg_saic.api", PKG_DIR / "api.py")
+    _load("mg_saic.backends", PKG_DIR / "backends" / "__init__.py")
+    sys.modules["mg_saic.backends"].__path__ = [str(PKG_DIR / "backends")]
+    INDIA = _load("mg_saic.backends.india", PKG_DIR / "backends" / "india.py")
+
+    from mg_ismart_india_client.models import ChargeStatus
+
+
+# Field names the charging adapter reads off ChargeStatus. Listed here rather
+# than scraped from the source so that adding an access without checking the
+# pinned release provides it is a deliberate two-file change.
+CHARGE_FIELDS_READ = (
+    "is_charging",
+    "is_plugged_in",
+    "soc",
+    "range_km",
+    "charging_voltage",
+    "charging_current",
+    "battery_energy_kwh",
+    "charge_time_elapsed_s",
+    "charge_time_remaining_min",
+    "odometer_km",
+    "distance_since_last_charge_km",
+    "power_usage_since_last_charge_kwh",
+    "total_battery_capacity_kwh",
+)
+
+
+@unittest.skipUnless(
+    CLIENT_INSTALLED, "mg-ismart-india-client is not installed in this environment"
+)
+class TestChargeStatusContract(unittest.TestCase):
+    """The pinned client must supply every field the adapter reads."""
+
+    def _charge(self, **overrides):
+        """A ChargeStatus built from the real released model.
+
+        Every field is passed by keyword, so a rename or removal in a future
+        release fails here rather than silently in production.
+        """
+        values = dict(
+            is_charging=True,
+            is_plugged_in=True,
+            charging_type=1,
+            charging_electricity_phase=1,
+            soc=62.5,
+            range_km=85.2,
+            charging_voltage=360.0,
+            charging_current=15.6,
+            battery_energy_kwh=31.75,
+            working_voltage=None,
+            working_current=None,
+            charge_time_elapsed_s=90,
+            start_time=None,
+            end_time=None,
+            charge_time_remaining_min=186,
+            charging_pile_id=None,
+            charging_pile_supplier=None,
+            odometer_km=1234.5,
+            distance_since_last_charge_km=45.6,
+            power_usage_since_last_charge_kwh=4.0,
+            mileage_of_day_raw=None,
+            power_usage_of_day_raw=None,
+            static_energy_consumption_raw=None,
+            total_battery_capacity_kwh=None,
+            last_charge_ending_power_kwh=None,
+            fota_lowest_voltage_raw=None,
+            status_time=1_750_000_000,
+            _raw={},
+        )
+        values.update(overrides)
+        return ChargeStatus(**values)
+
+    def _map(self, charge):
+        backend = INDIA.IndiaBackend("user", "password", vin="VIN1")
+        backend._charge_status_by_vin["VIN1"] = charge
+        return _run(backend.get_charging_info("VIN1"))
+
+    def test_every_field_the_adapter_reads_exists_on_the_pinned_model(self):
+        charge = self._charge()
+        for name in CHARGE_FIELDS_READ:
+            with self.subTest(field=name):
+                self.assertTrue(
+                    hasattr(charge, name),
+                    f"{name} is missing from the pinned mg-ismart-india-client; "
+                    "bump the pin in manifest.json",
+                )
+
+    def test_charging_frame_maps_off_a_real_charge_status(self):
+        charging = self._map(self._charge())
+
+        self.assertEqual(charging.chrgMgmtData.bmsPackSOCDsp, 625)
+        self.assertEqual(charging.chrgMgmtData.chrgngRmnngTime, 186)
+        self.assertEqual(charging.rvsChargeStatus.fuelRangeElec, 852)
+        self.assertEqual(charging.rvsChargeStatus.mileage, 12345)
+        self.assertEqual(charging.rvsChargeStatus.mileageSinceLastCharge, 456)
+        # Real kWh, taken as-is rather than reconstructed.
+        self.assertEqual(charging.rvsChargeStatus.packEnergyKwh, 31.75)
+        self.assertEqual(charging.rvsChargeStatus.powerUsageSinceLastCharge, 40)
+        self.assertEqual(charging.rvsChargeStatus.lastChargeEndingPower, 358)
+
+    def test_optional_fields_absent_from_the_frame_map_to_none(self):
+        # The ASN.1 marks these OPTIONAL, and the client resolves an absent or
+        # sentinel value to None. The adapter must carry that through instead
+        # of raising or inventing a figure.
+        charging = self._map(
+            self._charge(
+                charge_time_remaining_min=None,
+                power_usage_since_last_charge_kwh=None,
+                distance_since_last_charge_km=None,
+            )
+        )
+
+        self.assertIsNone(charging.chrgMgmtData.chrgngRmnngTime)
+        self.assertIsNone(charging.rvsChargeStatus.powerUsageSinceLastCharge)
+        self.assertIsNone(charging.rvsChargeStatus.lastChargeEndingPower)
+        self.assertIsNone(charging.rvsChargeStatus.mileageSinceLastCharge)
+        # Pack energy does not depend on any of them.
+        self.assertEqual(charging.rvsChargeStatus.packEnergyKwh, 31.75)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -652,6 +652,51 @@ class TestReachabilityDebounce(unittest.TestCase):
         self.assertTrue(c._code4_this_cycle)
 
 
+class PackEnergyTests(unittest.TestCase):
+    """#302: a backend that knows its pack energy in real kWh short-circuits
+    the global reconstruction.
+
+    Without this, Last Charge Energy was blank on every India car: the frame
+    has no lastChargeEndingPower the global identity can use, and no
+    totalBatteryCapacity for the SOC route to fall back on.
+    """
+
+    def _coordinator(self, rvs, correction=None):
+        Coord = sys.modules["mg_saic.coordinator"].SAICMGDataUpdateCoordinator
+        c = Coord.__new__(Coord)
+        c.charging_capacity_correction = correction
+        c.data = {"charging": types.SimpleNamespace(rvsChargeStatus=rvs)}
+        return c
+
+    def test_direct_pack_energy_wins_over_the_reconstruction(self):
+        # A backend that reports pack energy outright is authoritative, even
+        # when the reconstruction inputs are also present and disagree.
+        c = self._coordinator(
+            types.SimpleNamespace(
+                packEnergyKwh=23.4,
+                lastChargeEndingPower=234,
+                powerUsageSinceLastCharge=124,
+            )
+        )
+        self.assertAlmostEqual(c._extract_pack_energy_kwh(c.data["charging"]), 23.4)
+
+    def test_direct_pack_energy_skips_the_energy_correction(self):
+        # packEnergyKwh never went through the global raw scales, so the ~3×
+        # per-model correction must not be applied to it.
+        c = self._coordinator(
+            types.SimpleNamespace(packEnergyKwh=23.4), correction=1 / 3
+        )
+        self.assertAlmostEqual(c._extract_pack_energy_kwh(c.data["charging"]), 23.4)
+
+    def test_global_reconstruction_is_unchanged_without_the_field(self):
+        c = self._coordinator(
+            types.SimpleNamespace(
+                lastChargeEndingPower=600, powerUsageSinceLastCharge=100
+            )
+        )
+        self.assertAlmostEqual(c._extract_pack_energy_kwh(c.data["charging"]), 50.0)
+
+
 # ── Issue #250: in-place password update (reauth) ────────────────────────────
 
 


### PR DESCRIPTION
The follow-up @townsmcp asked for in #302, narrowed on review to the measured telemetry only: map the India charging fields that the car reports directly, and leave capacity selection alone.

**Pack energy.** The frame reports the energy sitting in the pack in real kWh, so it goes out as `packEnergyKwh` and the coordinator takes it directly, with no decimal or per-model energy correction — it never went through the global raw scales those corrections exist to undo. Last Charge Energy now works on every India model, with no capacity involved. Before this it was blank on every India car: the frame has no usable `lastChargeEndingPower` for the global identity to work from, and no `totalBatteryCapacity` for the SOC route to fall back on.

**Also mapped**, with scales derived from more captures: `powerUsageSinceLastCharge` (Power Usage Since Last Charge, Efficiency Since Charge) and `chrgngRmnngTime` (Remaining Charging Time).

**`lastChargeEndingPower` is reconstructed here**, not passed through, even though the client now exposes a field of that name. Despite the name, the India field tracks *live* pack energy — it equals `realtimePower` in all 23 archived frames and in every live poll. Passing it through would make the global `ending - powerUsageSinceLastCharge` identity compute 23.4 - 12.4 = 11.0 kWh against an actual 23.4 kWh in the pack. The real ending energy is `realtimePower + powerUsageSinceLastCharge`, which held steady at 348 through an entire charging session while both terms moved, became 373 when that session completed at 37.3 kWh, and was still 373 the next evening after 67 km of driving. The client decodes the field as sent and leaves the interpretation to the consumer, which is what this does.

`startTime`/`endTime` stay unmapped — `endTime` is not a real estimate, and there is no charge-start entity.

**Client pin.** Bumped to `mg-ismart-india-client==0.2.0`, which is where the renamed attributes this branch reads actually live.

**Contract test.** `tests/test_india_client_contract.py` deliberately does not stub `mg_ismart_india_client`. It builds a real `ChargeStatus` from the installed release and runs the charging adapter over it, asserting both that every field the adapter reads exists on the model and that the mapped frame comes out right. The CI workflow installs the client straight from the manifest pin, so what CI checks is the pin itself — a pin that lags the attributes the adapter needs now fails loudly instead of passing behind the hand-written fake. It skips when the client is not installed locally.

**Derived capacity is not in this PR.** It changes the capacity-selection behaviour several sensors read, so it follows separately rather than holding up the direct telemetry. `logic.py` and the capacity resolver are untouched here, and `README.md` does not change.

Depends on john-lazarus/mg-ismart-india-client#9, released as [v0.2.0](https://github.com/john-lazarus/mg-ismart-india-client/releases/tag/v0.2.0).

Ref: https://github.com/townsmcp/mg-saic-ha/pull/302#issuecomment-5490913804

🤖 Generated with [Claude Code](https://claude.com/claude-code)
