### PR TITLE
fix: multi-poll regen still rebased (#354 take two), and trip-close charge/refuel inference (#354)

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.9-beta1"
+  "version": "1.2.9-beta2"
 }

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -204,6 +204,25 @@ def _counter_delta(current, baseline_value):
     return round(current - baseline_value, 3)
 
 
+def _overlaps(charge, start_ts, end_ts):
+    """True if a completed charge session's window intersects [start_ts, end_ts].
+
+    ``charge`` is a trip_stats manager's ``last_charge`` dict (or None) — the
+    same record ``compute_charge_session`` produces, carrying ``start_ts``/
+    ``end_ts`` as ISO-8601 strings, which sort correctly as plain strings.
+    Returns False on anything malformed rather than raising, since this is
+    only ever used to decide whether to trust a heuristic, never something
+    load-bearing enough to justify an exception mid-trip-close.
+    """
+    if not charge:
+        return False
+    charge_start = charge.get("start_ts")
+    charge_end = charge.get("end_ts")
+    if not charge_start or not charge_end:
+        return False
+    return charge_start <= end_ts and charge_end >= start_ts
+
+
 def _efficiency_block(distance_km, distance_mi, energy_kwh):
     """The 5-key energy/efficiency block for one (distance, energy) pairing.
     Shared by the primary, _counter, and _soc figures so all three stay
@@ -242,6 +261,7 @@ def compute_completed_trip(
     is_electric: bool,
     is_combustion: bool,
     retrospective: bool = False,
+    last_charge: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Compute a completed-trip dict for the drive ending at ``end``.
 
@@ -307,7 +327,21 @@ def compute_completed_trip(
     charged_during_park = False
     if is_electric and start.soc_pct is not None and end.soc_pct is not None:
         soc_delta = round(start.soc_pct - end.soc_pct, 1)
-        if soc_delta < 0:
+        # A rise here is not on its own evidence of an external charge — a
+        # PHEV/HEV's engine or regen can legitimately raise SOC net across a
+        # trip with nothing plugged in at all (#354's mistake, one code path
+        # over: any SOC rise treated as proof of an outside event). The
+        # positive check available here is the manager's own charge-session
+        # tracking: if a completed charge's window actually overlaps this
+        # trip, that is real evidence, not an inference from SOC alone.
+        #
+        # Without that evidence, a negative soc_used_pct is left as a
+        # genuine net gain rather than hidden — _efficiency_block already
+        # returns all-None below when energy is zero or negative, so the
+        # (meaningless) efficiency figures blank themselves out on their
+        # own; the raw SOC/energy delta stays visible rather than the whole
+        # block vanishing along with a misleading "charged" flag.
+        if soc_delta < 0 and _overlaps(last_charge, start.ts, end.ts):
             charged_during_park = True
         else:
             soc_used_pct = soc_delta
@@ -408,8 +442,17 @@ def compute_completed_trip(
     # ── Fuel (ICE/HEV/PHEV) ──────────────────────────────────────────────────
     if is_combustion and start.fuel_pct is not None and end.fuel_pct is not None:
         fuel_used = round(start.fuel_pct - end.fuel_pct, 1)
+        # No refuel-session tracking exists to check against (unlike the SOC
+        # case above, which has real charge-session data available) — a
+        # rise here is left as a negative fuel_used_pct (a small net gain,
+        # most plausibly gauge noise) rather than guessed at. A genuine
+        # refuel mid-trip is rare enough, and a wrong guess costly enough
+        # (silently discarding real consumption figures), that showing the
+        # raw number honestly beats flagging an event we have no way to
+        # actually confirm.
         if fuel_used < 0:
             trip["refuelled_during_park"] = True
+            trip["fuel_used_pct"] = fuel_used
         else:
             trip["fuel_used_pct"] = fuel_used
             if tank_litres:
@@ -779,20 +822,31 @@ class TripStatsManager:
             "soc_low_pct", self.soc_reset_baseline.get("soc_pct", soc_pct)
         )
         if soc_pct >= low + SOC_CHARGE_RISE_PCT:
-            # A rise, but from what? If the odometer moved since the last
-            # parked reading, the car drove here and the gain is regen, so the
-            # baseline must stand or the leg just driven is erased from the
-            # figures (#354). If it did not move, the energy came from
-            # outside the car: a charge, including one that finished while
-            # Home Assistant was down or while the charging endpoint was
-            # silent, neither of which we would otherwise see.
-            if previous is not None and (
-                abs(odometer_km - previous["odometer_km"]) >= REGEN_ODOMETER_MOVED_KM
+            # A rise above the low-water mark, but from what? Two conditions
+            # must BOTH hold for this to be a charge: the car hasn't moved
+            # since the last parked reading (charging happens standing
+            # still), AND SOC is higher than that SAME reading — not merely
+            # above the low-water mark in general.
+            #
+            # The second condition is not optional. Without it, a LATER poll
+            # sitting at an already-explained regen value looks identical to
+            # a fresh charge signal: hasn't moved, still above the low. That
+            # is exactly what broke the first version of this fix in the
+            # field (#354, confirmed on 1.2.9-beta1 by @SteveMSJ): arrive at
+            # a spot via regen, correctly hold; a SECOND poll at the same
+            # spot, unmoved, sees "hasn't moved AND above the low" all over
+            # again and rebases onto its own earlier "this was regen"
+            # conclusion, discarding the outbound leg exactly as before.
+            # Comparing against the immediate previous reading rather than
+            # the low-water mark closes that gap: sitting still at an
+            # unchanged SOC is "nothing new happened", not fresh evidence.
+            if (
+                previous is not None
+                and abs(odometer_km - previous["odometer_km"]) < REGEN_ODOMETER_MOVED_KM
+                and soc_pct > previous["soc_pct"]
             ):
-                return True  # regen while driving — reading tracked, baseline held
-
-            self.soc_reset_baseline = self._new_soc_baseline(soc_pct, odometer_km, ts)
-            return True
+                self.soc_reset_baseline = self._new_soc_baseline(soc_pct, odometer_km, ts)
+            return True  # held (regen, or nothing new) — or rebased, above
 
         # Still discharging: track the new low so the next charge is measured
         # from the bottom of this cycle.
@@ -897,6 +951,7 @@ class TripStatsManager:
             tank_litres=tank_litres,
             is_electric=is_electric,
             is_combustion=is_combustion,
+            last_charge=self.last_charge,
         )
         return self._finalise(trip, snapshot)
 
@@ -956,6 +1011,7 @@ class TripStatsManager:
             tank_litres=tank_litres,
             is_electric=is_electric,
             is_combustion=is_combustion,
+            last_charge=self.last_charge,
             retrospective=True,
         )
         return self._finalise(trip, snapshot)
@@ -994,6 +1050,7 @@ class TripStatsManager:
             tank_litres=tank_litres,
             is_electric=is_electric,
             is_combustion=is_combustion,
+            last_charge=self.last_charge,
             retrospective=True,
         )
         return self._finalise(trip, end)

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -118,7 +118,7 @@ Notes and limitations:
 - SOC and fuel level are whole-number percentages, so figures for very short trips are coarse.
 - Trip *duration* is measured to the poll that detects shutdown, so treat it as approximate.
 - Fuel figures in litres / L per 100 km need a per-model tank size; until one is set for a given model, the fuel sensor reports **fuel % used** but not litres, L/100km or mpg.
-- If the car is charged or refuelled while parked mid-trip, that trip's electric/fuel figure is omitted and flagged (`charged_during_park` / `refuelled_during_park`) rather than reported wrongly.
+- A rise in SOC or fuel level across a trip isn't automatically treated as a charge or refuel — a PHEV/HEV's engine or regen can genuinely raise SOC net across a drive with nothing plugged in at all, and that's shown as the trip's actual figure rather than hidden. `charged_during_park` is only set when a completed charge recorded by the integration actually overlaps the trip's time window — real evidence, not an inference from SOC alone. There's no equivalent tracking for refuelling, so `refuelled_during_park` stays a heads-up alongside the honest (negative) fuel figure rather than something that blanks the trip.
 - When a value can't be computed yet, the efficiency sensors read **Unknown** rather than Unavailable — e.g. `Efficiency Since Last Charge` while charging or right after a charge (0 km driven since), or `Last Trip Efficiency` for a trip where a charge spanned the drive. The sensor's attributes still show the breakdown so you can see why.
 
 ### BINARY SENSORS

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -54,17 +54,54 @@ class TestBevTrip(unittest.TestCase):
         self.assertIsNone(trip["fuel_used_litres"])
 
     def test_charged_between_flags_and_skips_energy(self):
-        # SOC went UP (charged while parked before this drive's end reading).
+        # SOC went UP, AND a completed charge's window genuinely overlaps
+        # this trip -- real evidence, not an inference from SOC alone (#354:
+        # a PHEV/HEV's engine or regen can raise SOC net across a trip with
+        # nothing plugged in, so a rise on its own is no longer trusted).
+        start = snap(1000.0, soc=50.0, t="2026-08-21T09:00:00+00:00")
+        end = snap(1010.0, soc=60.0, t="2026-08-21T09:30:00+00:00")
+        last_charge = {
+            "start_ts": "2026-08-21T09:05:00+00:00",
+            "end_ts": "2026-08-21T09:20:00+00:00",
+        }
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False, last_charge=last_charge,
+        )
+        self.assertEqual(trip["distance_km"], 10.0)  # distance still valid
+        self.assertTrue(trip["charged_during_park"])
+        self.assertIsNone(trip["energy_kWh"])
+        self.assertIsNone(trip["efficiency_km_per_kWh"])
+
+    def test_soc_rise_with_no_charge_evidence_is_shown_as_a_net_gain(self):
+        """The counterpart (#354): same SOC rise, but nothing confirms a
+        charge happened. Treated as a genuine net gain -- likely regen or
+        engine-charging on a PHEV/HEV -- not silently flagged and hidden."""
         start = snap(1000.0, soc=50.0)
         end = snap(1010.0, soc=60.0)
         trip = ts.compute_completed_trip(
             start, end, capacity_kwh=64.0, tank_litres=None,
             is_electric=True, is_combustion=False,
         )
-        self.assertEqual(trip["distance_km"], 10.0)  # distance still valid
-        self.assertTrue(trip["charged_during_park"])
-        self.assertIsNone(trip["energy_kWh"])
+        self.assertFalse(trip["charged_during_park"])
+        self.assertEqual(trip["soc_used_pct"], -10.0)
+        # _efficiency_block already blanks itself on non-positive energy --
+        # no separate clamping needed for this to come out sane.
         self.assertIsNone(trip["efficiency_km_per_kWh"])
+
+    def test_charge_evidence_outside_the_trip_window_does_not_count(self):
+        start = snap(1000.0, soc=50.0, t="2026-08-21T09:00:00+00:00")
+        end = snap(1010.0, soc=60.0, t="2026-08-21T09:30:00+00:00")
+        last_charge = {  # a real charge, but hours before this trip
+            "start_ts": "2026-08-21T02:00:00+00:00",
+            "end_ts": "2026-08-21T04:00:00+00:00",
+        }
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=64.0, tank_litres=None,
+            is_electric=True, is_combustion=False, last_charge=last_charge,
+        )
+        self.assertFalse(trip["charged_during_park"])
+        self.assertEqual(trip["soc_used_pct"], -10.0)
 
     def test_missing_capacity_gives_distance_and_soc_only(self):
         start = snap(1000.0, soc=80.0)
@@ -117,6 +154,38 @@ class TestPhevTrip(unittest.TestCase):
         self.assertEqual(trip["distance_km"], 50.0)
         self.assertAlmostEqual(trip["energy_kWh"], 2.0, places=3)  # 10% of 20
         self.assertAlmostEqual(trip["fuel_used_litres"], 1.6, places=2)  # 4% of 40
+
+    def test_engine_charging_raises_soc_with_no_plug_involved(self):
+        """@HarryFlatter's report (#354): a PHEV/HEV's engine or regen can
+        raise SOC net across a trip with nothing plugged in at all. Shown as
+        a net gain, not silently hidden behind a misleading charged flag —
+        the fuel side, driven independently, is unaffected."""
+        start = snap(2000.0, soc=70.0, fuel=80.0)
+        end = snap(2050.0, soc=71.4, fuel=76.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=20.0, tank_litres=40.0,
+            is_electric=True, is_combustion=True,
+        )
+        self.assertFalse(trip["charged_during_park"])
+        self.assertAlmostEqual(trip["soc_used_pct"], -1.4, places=3)
+        self.assertIsNone(trip["efficiency_km_per_kWh"])
+        self.assertAlmostEqual(trip["fuel_used_litres"], 1.6, places=2)
+
+    def test_fuel_level_rise_is_shown_not_hidden(self):
+        """No refuel-session tracking exists to check against, unlike the
+        SOC case above -- shown as the raw (negative) delta rather than
+        guessed at, with the flag kept as a heads-up rather than a reason to
+        blank the trip."""
+        start = snap(2000.0, soc=70.0, fuel=40.0)
+        end = snap(2050.0, soc=60.0, fuel=41.0)
+        trip = ts.compute_completed_trip(
+            start, end, capacity_kwh=20.0, tank_litres=40.0,
+            is_electric=True, is_combustion=True,
+        )
+        self.assertTrue(trip["refuelled_during_park"])
+        self.assertAlmostEqual(trip["fuel_used_pct"], -1.0, places=3)
+        self.assertIsNone(trip["fuel_used_litres"])
+        self.assertAlmostEqual(trip["energy_kWh"], 2.0, places=3)  # SOC side unaffected
 
 
 class TestInvalidTrips(unittest.TestCase):
@@ -496,6 +565,45 @@ class TestNoteSocResetBaseline(unittest.TestCase):
         )
         self.assertAlmostEqual(m.soc_reset_baseline["soc_pct"] - 78.4, 1.6, places=1)
 
+    def test_a_second_poll_at_the_same_regen_spot_does_not_rebase(self):
+        """The exact way the first version of this fix broke in the field
+        (#354): @SteveMSJ updated to 1.2.9-beta1, repeated the same downhill
+        walk, and the baseline STILL rebased to the regen-elevated reading —
+        because a second poll landed while he was still parked at the wood,
+        unchanged from the first, and "hasn't moved, still above the low"
+        was satisfied a second time using the fix's own earlier "this was
+        regen" conclusion as if it were new evidence.
+        """
+        m = self._mgr()
+        m.note_soc_reset_baseline(80.0, 16941.69, "t1")       # home, post-charge
+        m.note_soc_reset_baseline(80.6, 16946.66, "t2")       # wood, regen, held
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 16941.69)
+
+        # Still parked at the wood — a second poll, unchanged.
+        m.note_soc_reset_baseline(80.6, 16946.66, "t3")
+        self.assertEqual(
+            m.soc_reset_baseline["odometer_km"],
+            16941.69,
+            "a second unchanged reading at the same spot must not rebase",
+        )
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 80.0)
+
+        m.note_soc_reset_baseline(79.2, 16946.66 + 4.97, "t4")  # home again
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 80.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 16941.69)
+
+    def test_soc_climbing_further_while_still_at_the_same_spot_does_rebase(self):
+        """The counterpart the fix must not lose: charging in place, across
+        several polls, with SOC genuinely climbing each time — not just
+        holding at the same value — must still be recognised as a charge."""
+        m = self._mgr()
+        m.note_soc_reset_baseline(60.0, 2000.0, "t1")
+        m.note_soc_reset_baseline(60.8, 2010.0, "t2")   # arrived, regen, held
+        for soc in (65.0, 70.0, 75.0):
+            m.note_soc_reset_baseline(soc, 2010.0, "t")
+        self.assertEqual(m.soc_reset_baseline["soc_pct"], 75.0)
+        self.assertEqual(m.soc_reset_baseline["odometer_km"], 2010.0)
+
     def test_charge_while_stationary_still_rebases(self):
         """The counterpart: same SOC rise, but the car hasn't moved, so the
         energy came from outside — including a charge finished while Home
@@ -634,13 +742,30 @@ class TestRetrospectiveTrip(unittest.TestCase):
         m.detect_missed_trip(
             Snap(ts="2026-08-21T06:00:00+00:00", odometer_km=2000.0, soc_pct=40.0),
             **self._kw)
-        # SOC rose (a charge happened somewhere in the gap) -> no electric figure.
+        # A completed charge recorded during the gap overlaps it -> flagged.
+        m.last_charge = {
+            "start_ts": "2026-08-21T07:00:00+00:00",
+            "end_ts": "2026-08-21T09:00:00+00:00",
+        }
         trip = m.detect_missed_trip(
             Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2015.0, soc_pct=90.0),
             **self._kw)
         self.assertEqual(trip["distance_km"], 15.0)
         self.assertTrue(trip["charged_during_park"])
         self.assertIsNone(trip["efficiency_km_per_kWh"])
+
+    def test_soc_rise_in_gap_with_no_charge_record_is_a_net_gain(self):
+        """No completed charge was recorded overlapping the gap -- reported
+        as the raw (negative) delta rather than assumed to be a charge."""
+        m = self._mgr()
+        m.detect_missed_trip(
+            Snap(ts="2026-08-21T06:00:00+00:00", odometer_km=2000.0, soc_pct=40.0),
+            **self._kw)
+        trip = m.detect_missed_trip(
+            Snap(ts="2026-08-21T10:00:00+00:00", odometer_km=2015.0, soc_pct=90.0),
+            **self._kw)
+        self.assertFalse(trip["charged_during_park"])
+        self.assertEqual(trip["soc_used_pct"], -50.0)
 
 
 class TestForceCloseStale(unittest.TestCase):


### PR DESCRIPTION
Two fixes, same root cause across two different code paths. Fixes #354, both threads.

## Part 1: the #356 fix still broke in the field

@SteveMSJ reproduced the identical bug on 1.2.9-beta1. Traced through the actual merged code against his real sequence: the comparison is against whatever the *previous parked reading* happened to be — and the previous reading gets overwritten by the regen reading itself, once it's correctly identified as regen and held.

A **second** poll landing while still parked at the same spot — inevitable for any stop longer than one poll interval — compares against that stored regen value. "Hasn't moved since then, still above the low-water mark" is true a second time, and the fix rebases onto its own earlier "this was regen" conclusion.

**Fix:** a rise only counts as a charge when the car hasn't moved *and* SOC is higher than that **same previous reading** — not merely above the low-water mark in general. Sitting still at an already-explained value is "nothing new happened," not fresh evidence.

**Verified this specific gap:** reverted to the #356 comparison and confirmed the new regression test fails with the exact symptom Steve reported, before restoring the fix.

## Part 2: trip-close charge/refuel inference (@HarryFlatter, #354)

Separate code — `compute_completed_trip`, not `note_soc_reset_baseline` — had the same category of mistake: any SOC or fuel rise across a completed trip was assumed to mean an external charge/refuel happened mid-trip, discarding the whole efficiency block. A PHEV/HEV's engine or regen can legitimately raise SOC net across a drive with nothing plugged in. Trip boundaries always involve movement, so part 1's odometer trick doesn't transfer directly here.

For **SOC**, real evidence exists: the manager's own charge-session tracking (`last_charge`) already records completed charges with `start_ts`/`end_ts`. `charged_during_park` is now only set when a recorded charge's window actually **overlaps** the trip. Without that evidence, the rise is shown as a genuine negative `soc_used_pct` rather than hidden — `_efficiency_block` already returns all-None on non-positive energy, so the meaningless efficiency figures blank themselves out with no new clamping needed.

For **fuel**, there's no equivalent session tracking to check against, so a rise is shown as the raw negative delta, with `refuelled_during_park` kept as a heads-up rather than something that blanks the trip. A wrong guess here is costly (discards real consumption data), and refuelling mid-trip is rare enough that showing the honest number beats guessing at an event we can't confirm.

`compute_completed_trip` gains a `last_charge` parameter; all three call sites (`close`, `detect_missed_trip`, `force_close_if_stale`) pass `self.last_charge`.

## Testing

9 new/updated tests, including Steve's exact real numbers as a multi-poll fixture and both PHEV counterparts (engine-charging shown as net gain / fuel rise shown not hidden). 311 pass, pyflakes clean.

`docs/sensors.md` updated. Version `1.2.9-beta2`.