### PR TITLE
fix: fuelRangeElec=0 broke ERAC and Range Added; add fuel tank size override (#354)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This README covers installation and initial setup. Everything else lives in its 
 
 | Page | What's in it |
 |---|---|
-| [Sensors & Vehicle Profiles](docs/sensors.md) | Every sensor and binary sensor, trip/efficiency statistics, entity state reference, per-model vehicle profile notes, and the battery capacity override |
+| [Sensors & Vehicle Profiles](docs/sensors.md) | Every sensor and binary sensor, trip/efficiency statistics, entity state reference, per-model vehicle profile notes, and the battery capacity / fuel tank size overrides |
 | [Controlling Your Car](docs/controls.md) | Climate control (both control schemes), windows, heated seats, and event-driven updates |
 | [MG India Support](docs/india.md) | Setup, what's confirmed working, and current limitations for India-region vehicles |
 | [A Better Route Planner (ABRP)](docs/abrp.md) | Connecting your car's live data to ABRP |

--- a/custom_components/mg_saic/config_flow.py
+++ b/custom_components/mg_saic/config_flow.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_HOLIDAY_UPDATE_INTERVAL,
     CONF_STALE_DATA_THRESHOLD,
     CONF_BATTERY_CAPACITY_OVERRIDE,
+    CONF_FUEL_TANK_OVERRIDE,
     DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
     DEFAULT_STALE_DATA_THRESHOLD_HOURS,
     AFTER_ACTION_UPDATE_INTERVAL_DELAY,
@@ -573,9 +574,26 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                 return
             user_input[CONF_BATTERY_CAPACITY_OVERRIDE] = value
 
+        def _normalise_tank(user_input, errors):
+            """Blank clears the override; otherwise store a validated float."""
+            raw = user_input.get(CONF_FUEL_TANK_OVERRIDE, "")
+            if raw in (None, ""):
+                user_input.pop(CONF_FUEL_TANK_OVERRIDE, None)
+                return
+            try:
+                value = float(raw)
+            except (TypeError, ValueError):
+                errors[CONF_FUEL_TANK_OVERRIDE] = "tank_invalid"
+                return
+            if not 1 <= value <= 200:
+                errors[CONF_FUEL_TANK_OVERRIDE] = "tank_out_of_range"
+                return
+            user_input[CONF_FUEL_TANK_OVERRIDE] = value
+
         if user_input is not None:
             errors = await self._validate_abrp(user_input)
             _normalise_capacity(user_input, errors)
+            _normalise_tank(user_input, errors)
             if not errors:
                 return self.async_create_entry(title="", data=user_input)
 
@@ -640,6 +658,19 @@ class SAICMGOptionsFlowHandler(config_entries.OptionsFlow):
                     description={
                         "suggested_value": self.options.get(
                             CONF_BATTERY_CAPACITY_OVERRIDE, ""
+                        )
+                    },
+                ): str,
+                # Petrol tank size override (litres), for the fuel figures on
+                # ICE/HEV/PHEV models. Same text-field/suggested_value pattern
+                # as the capacity override above so blank clears it. Unlike
+                # battery capacity there is no API-reported value to fall back
+                # to, so this overrides our per-model figure and nothing else.
+                vol.Optional(
+                    CONF_FUEL_TANK_OVERRIDE,
+                    description={
+                        "suggested_value": self.options.get(
+                            CONF_FUEL_TANK_OVERRIDE, ""
                         )
                     },
                 ): str,

--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -936,6 +936,7 @@ CONF_STALE_DATA_THRESHOLD = "stale_data_threshold_hours"
 # User-supplied usable battery capacity (kWh). Overrides both our per-model
 # profile value and the API-reported totalBatteryCapacity. Empty/0 = no override.
 CONF_BATTERY_CAPACITY_OVERRIDE = "battery_capacity_override_kwh"
+CONF_FUEL_TANK_OVERRIDE = "fuel_tank_override_litres"
 
 
 def parse_capacity_override(raw):

--- a/custom_components/mg_saic/coordinator.py
+++ b/custom_components/mg_saic/coordinator.py
@@ -13,6 +13,7 @@ from .backends import Feature
 from .backends import backend_supports as _backend_supports
 from .logic import (
     TARGET_SOC_PERCENT_BY_CODE,
+    resolve_fuel_tank_litres,
     apply_energy_correction,
     electric_range_km,
     project_range_at_target,
@@ -43,6 +44,7 @@ from .const import (
     CONF_HOLIDAY_UPDATE_INTERVAL,
     CONF_STALE_DATA_THRESHOLD,
     CONF_BATTERY_CAPACITY_OVERRIDE,
+    CONF_FUEL_TANK_OVERRIDE,
     parse_capacity_override,
     DEFAULT_HOLIDAY_UPDATE_INTERVAL_HOURS,
     DEFAULT_STALE_DATA_THRESHOLD_HOURS,
@@ -218,6 +220,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # full integration reload — see async_update_options.
         self._profile_battery_capacity_kwh = None
         self.known_fuel_tank_litres = None  # Per-model tank size, for fuel stats (#301)
+        self.fuel_tank_override = None  # User override; set from options below
         # Trip/efficiency stats manager (#301). Created and loaded in async_setup.
         self.trip_stats = None
         # Climate control profile — set from VEHICLE_PROFILES on first data fetch.
@@ -406,6 +409,12 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # known_battery_capacity_kwh is resolved once the series is known.
         self.battery_capacity_override = parse_capacity_override(
             config_entry.options.get(CONF_BATTERY_CAPACITY_OVERRIDE, None)
+        )
+        # User-supplied petrol tank size (litres). Same precedence idea as the
+        # capacity override, minus the API tier — SAIC reports no tank size at
+        # all, so this overrides our per-model figure and nothing else.
+        self.fuel_tank_override = parse_capacity_override(
+            config_entry.options.get(CONF_FUEL_TANK_OVERRIDE, None)
         )
         self.has_heated_seats = config_entry.options.get(
             "has_heated_seats", config_entry.data.get("has_heated_seats", False)
@@ -716,6 +725,9 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         # plain options save) — the sensor kept showing the stale/API value.
         self.battery_capacity_override = parse_capacity_override(
             options.get(CONF_BATTERY_CAPACITY_OVERRIDE, None)
+        )
+        self.fuel_tank_override = parse_capacity_override(
+            options.get(CONF_FUEL_TANK_OVERRIDE, None)
         )
         self.known_battery_capacity_kwh = (
             self.battery_capacity_override
@@ -1442,7 +1454,7 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
         snap = self._trip_snapshot(basic_status, charging_data)
         trip_kwargs = dict(
             capacity_kwh=self.effective_battery_capacity_kwh,
-            tank_litres=self.known_fuel_tank_litres,
+            tank_litres=self.effective_fuel_tank_litres,
             is_electric=self.vehicle_type in ("BEV", "PHEV"),
             is_combustion=self.vehicle_type in ("ICE", "HEV", "PHEV"),
         )
@@ -1513,6 +1525,22 @@ class SAICMGDataUpdateCoordinator(DataUpdateCoordinator):
             self._api_battery_capacity_raw(),
             factor=DATA_DECIMAL_CORRECTION,
         )
+
+    @property
+    def fuel_tank_resolution(self):
+        """(litres, source) using override > our per-model figure, or (None, None).
+
+        No API tier: SAIC reports no tank size, so unlike battery capacity
+        there is nothing to fall back to beyond our own table (#354).
+        """
+        return resolve_fuel_tank_litres(
+            self.fuel_tank_override, self.known_fuel_tank_litres
+        )
+
+    @property
+    def effective_fuel_tank_litres(self):
+        """Petrol tank size in litres from either tier, or None."""
+        return self.fuel_tank_resolution[0]
 
     @property
     def effective_battery_capacity_kwh(self):

--- a/custom_components/mg_saic/logic.py
+++ b/custom_components/mg_saic/logic.py
@@ -163,7 +163,19 @@ def electric_range_km(basic_status, charging_data, *, factor):
         if source is None:
             continue
         raw = getattr(source, "fuelRangeElec", None)
-        if raw is not None and raw >= 0 and raw != ELECTRIC_RANGE_SENTINEL:
+        # 0 means "not reported", not "no range left". On an MG HS PHEV
+        # mid-charge, rvsChargeStatus.fuelRangeElec sits at 0 for the whole
+        # session while imcuVehElecRng climbs 75 -> 120 km, so accepting the 0
+        # short-circuits the imcu fallback below and hands every caller a
+        # range of zero (#354). That silently produced BOTH of that car's
+        # symptoms at once: the range-after-charging projection divides by a
+        # zero range and gives up, and the charge-session range delta comes
+        # out 0 - 0 = 0, hence "Last Charge Range Added: 0.0 mi" against a
+        # charge that really added ~28 miles. A car genuinely at zero range
+        # loses nothing here: the imcu fallback answers instead, and if that
+        # is also absent, None is more honest than a zero that breaks
+        # everything downstream.
+        if raw is not None and raw > 0 and raw != ELECTRIC_RANGE_SENTINEL:
             return round(raw * factor, 1)
 
     # Last resort: the IMCU's own vehicle range. Some models never populate a
@@ -239,6 +251,30 @@ TARGET_SOC_PERCENT_BY_CODE = {1: 40, 2: 50, 3: 60, 4: 70, 5: 80, 6: 90, 7: 100}
 # Below this SOC a range projection amplifies noise too much to be useful: at
 # 5% SOC a single percentage point of error swings the result by 20%.
 MIN_SOC_PCT_FOR_RANGE_PROJECTION = 12.0
+
+
+def resolve_fuel_tank_litres(override_litres, profile_litres):
+    """Resolve the petrol tank size and say where it came from.
+
+    Mirrors resolve_battery_capacity, with one real difference: the SAIC API
+    reports no tank size at all, so there is no third "api" tier to fall back
+    to — only a user override and our per-model figure.
+
+    Returns ``(litres, source)`` where source is ``"user_override"``,
+    ``"profile"``, or ``None`` when neither is available (in which case the
+    fuel sensors report % used but not litres, L/100km or mpg, as before).
+
+    The override exists because tank sizes are market-split in ways the
+    series code can't distinguish — the MG HS PHEV is documented at 37 L for
+    some markets, and owners of 2025/26 UK cars report filling far more than
+    that (#354). A per-owner override settles it without us having to pick a
+    single number for a model that genuinely ships with more than one.
+    """
+    if override_litres is not None:
+        return override_litres, "user_override"
+    if profile_litres is not None:
+        return profile_litres, "profile"
+    return None, None
 
 
 def project_range_at_target(current_range, soc_pct, target_soc_pct, *, min_soc_pct=MIN_SOC_PCT_FOR_RANGE_PROJECTION):

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.1.8"
   ],
-  "version": "1.2.9-beta2"
+  "version": "1.2.9-beta3"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3277,6 +3277,7 @@ _TRIP_ATTR_KEYS = (
     "consumption_kWh_per_100km_soc",
     "consumption_kWh_per_100mi_soc",
     "fuel_used_pct",
+    "fuel_tank_litres",
     "fuel_used_litres",
     "fuel_consumption_L_per_100km",
     "fuel_economy_mpg_uk",

--- a/custom_components/mg_saic/translations/en.json
+++ b/custom_components/mg_saic/translations/en.json
@@ -393,6 +393,7 @@
           "has_steering_wheel_heat": "Has Steering Wheel Heat",
           "has_window_control": "Has Window Control (Open/Close/Ventilate)",
           "battery_capacity_override_kwh": "Usable battery capacity override (kWh)",
+          "fuel_tank_override_litres": "Fuel tank size override (litres)",
           "enable_shutdown_refresh_sequence": "Enable Post-Shutdown Refresh Sequence",
           "abrp_user_token": "ABRP user token",
           "abrp_api_key": "ABRP API key"
@@ -401,6 +402,7 @@
         "title": "MG/SAIC Options",
         "data_description": {
           "battery_capacity_override_kwh": "Your car's usable battery capacity in kWh. Overrides the built-in value used for the Total Battery Capacity sensor and the efficiency/trip energy calculations — set this if your model's capacity is reported incorrectly. Leave blank to use the automatic value.",
+          "fuel_tank_override_litres": "Your car's petrol tank size in litres. Used for the litres, L/100km and mpg figures on the trip sensors. Tank sizes vary by market for the same model, so set this if the fuel figures look wrong for your car. Leave blank to use the built-in value.",
           "abrp_user_token": "Paste the user token from the ABRP app (Settings → your car → Live Data → Generic) to send this vehicle's data to A Better Route Planner. You also need your own API key (below) — both are required. Leave both blank to disable. See {abrp_doc_url}.",
           "abrp_api_key": "Enter your own Iternio API key, created in the Iternio developer portal — see {abrp_doc_url}. Required together with the user token to enable ABRP."
         }
@@ -412,7 +414,9 @@
       "abrp_no_api_key": "Enter your ABRP API key as well as your user token — both are required to enable ABRP.",
       "abrp_unknown": "Unexpected error validating the ABRP token.",
       "capacity_invalid": "Enter a number for the battery capacity (kWh), or leave it blank.",
-      "capacity_out_of_range": "Battery capacity must be between 1 and 250 kWh."
+      "capacity_out_of_range": "Battery capacity must be between 1 and 250 kWh.",
+      "tank_invalid": "Enter a number for the fuel tank size (litres), or leave it blank.",
+      "tank_out_of_range": "Fuel tank size must be between 1 and 200 litres."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/es.json
+++ b/custom_components/mg_saic/translations/es.json
@@ -77,7 +77,8 @@
       "invalid_pin": "El PIN debe tener exactamente 4 dígitos."
     },
     "abort": {
-      "already_configured": "All vehicles on this account are already configured in Home Assistant.",
+      "already_configured": "Todos los vehículos de esta cuenta ya están configurados en Home Assistant.",
+      "vin": "El vehículo con el VIN {vin} ya está configurado.",
       "india_backend_not_ready": "La compatibilidad con MG India está en desarrollo y aún no es funcional en esta versión. Sigue el issue #169 en GitHub para conocer el progreso.",
       "reauth_successful": "La reautenticación se ha realizado correctamente; la contraseña se ha actualizado.",
       "reconfigure_successful": "La contraseña se ha actualizado correctamente."
@@ -392,6 +393,7 @@
           "has_steering_wheel_heat": "Tiene calefacción en el volante",
           "has_window_control": "Control de ventanas (abrir/cerrar/ventilar)",
           "battery_capacity_override_kwh": "Anulación de la capacidad útil de la batería (kWh)",
+          "fuel_tank_override_litres": "Anulación de la capacidad del depósito de combustible (litros)",
           "enable_shutdown_refresh_sequence": "Habilitar secuencia de actualización tras apagado",
           "abrp_user_token": "Token de usuario de ABRP",
           "abrp_api_key": "Clave API de ABRP"
@@ -400,6 +402,7 @@
         "title": "Opciones de MG/SAIC",
         "data_description": {
           "battery_capacity_override_kwh": "Capacidad útil de la batería de tu coche en kWh. Anula el valor interno usado para el sensor de capacidad total de la batería y para los cálculos de eficiencia y energía de los viajes; úsalo si la capacidad de tu modelo se indica de forma incorrecta. Déjalo en blanco para usar el valor automático.",
+          "fuel_tank_override_litres": "La capacidad del depósito de combustible de tu coche en litros. Se usa para las cifras de litros, L/100 km y mpg de los sensores de trayecto. La capacidad del depósito varía según el mercado para un mismo modelo, así que ajústala si las cifras de combustible no cuadran con tu coche. Déjalo en blanco para usar el valor integrado.",
           "abrp_user_token": "Pega el token de usuario de la app ABRP (Ajustes → tu coche → Live Data → Generic) para enviar los datos de este vehículo a A Better Route Planner. También necesitas tu propia clave API (abajo); ambas son obligatorias. Deja ambas en blanco para desactivarlo. Consulta {abrp_doc_url}.",
           "abrp_api_key": "Introduce tu propia clave API de Iternio, creada en el portal de desarrolladores de Iternio: consulta {abrp_doc_url}. Obligatoria junto con el token de usuario para activar ABRP."
         }
@@ -411,7 +414,9 @@
       "abrp_no_api_key": "Introduce tu clave API de ABRP además del token de usuario: ambas son obligatorias para activar ABRP.",
       "abrp_unknown": "Error inesperado al validar el token de ABRP.",
       "capacity_invalid": "Introduce un número para la capacidad de la batería (kWh) o déjalo en blanco.",
-      "capacity_out_of_range": "La capacidad de la batería debe estar entre 1 y 250 kWh."
+      "tank_invalid": "Introduce un número para la capacidad del depósito (litros) o déjalo en blanco.",
+      "capacity_out_of_range": "La capacidad de la batería debe estar entre 1 y 250 kWh.",
+      "tank_out_of_range": "La capacidad del depósito debe estar entre 1 y 200 litros."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/fr.json
+++ b/custom_components/mg_saic/translations/fr.json
@@ -393,6 +393,7 @@
           "has_steering_wheel_heat": "Possède le volant chauffant",
           "has_window_control": "Possède le contrôle des vitres (Ouvrir/Fermer/Aérer)",
           "battery_capacity_override_kwh": "Remplacement de la capacité utile de la batterie (kWh)",
+          "fuel_tank_override_litres": "Remplacement de la capacité du réservoir de carburant (litres)",
           "enable_shutdown_refresh_sequence": "Activer la séquence de rafraîchissement post-arrêt",
           "abrp_user_token": "Jeton utilisateur ABRP",
           "abrp_api_key": "Clé API ABRP"
@@ -401,6 +402,7 @@
         "title": "Options MG/SAIC",
         "data_description": {
           "battery_capacity_override_kwh": "Capacité utile de la batterie de votre voiture en kWh. Remplace la valeur interne utilisée pour le capteur de capacité totale de la batterie et pour les calculs d'efficacité et d'énergie des trajets ; utilisez-la si la capacité de votre modèle est indiquée de façon incorrecte. Laissez vide pour utiliser la valeur automatique.",
+          "fuel_tank_override_litres": "La capacité du réservoir de carburant de votre voiture en litres. Utilisée pour les valeurs en litres, L/100 km et mpg des capteurs de trajet. La capacité du réservoir varie selon le marché pour un même modèle : renseignez-la si les valeurs de carburant semblent incorrectes pour votre voiture. Laissez vide pour utiliser la valeur intégrée.",
           "abrp_user_token": "Collez le jeton utilisateur de l'application ABRP (Paramètres → votre voiture → Live Data → Generic) pour envoyer les données de ce véhicule à A Better Route Planner. Vous avez aussi besoin de votre propre clé API (ci-dessous) ; les deux sont requises. Laissez les deux vides pour désactiver. Voir {abrp_doc_url}.",
           "abrp_api_key": "Saisissez votre propre clé API Iternio, créée dans le portail développeur Iternio — voir {abrp_doc_url}. Requise avec le jeton utilisateur pour activer ABRP."
         }
@@ -412,7 +414,9 @@
       "abrp_no_api_key": "Saisissez votre clé API ABRP en plus de votre jeton utilisateur — les deux sont requis pour activer ABRP.",
       "abrp_unknown": "Erreur inattendue lors de la validation du jeton ABRP.",
       "capacity_invalid": "Saisissez un nombre pour la capacité de la batterie (kWh), ou laissez vide.",
-      "capacity_out_of_range": "La capacité de la batterie doit être comprise entre 1 et 250 kWh."
+      "tank_invalid": "Saisissez un nombre pour la capacité du réservoir (litres), ou laissez vide.",
+      "capacity_out_of_range": "La capacité de la batterie doit être comprise entre 1 et 250 kWh.",
+      "tank_out_of_range": "La capacité du réservoir doit être comprise entre 1 et 200 litres."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/translations/pt.json
+++ b/custom_components/mg_saic/translations/pt.json
@@ -393,6 +393,7 @@
           "has_steering_wheel_heat": "Tem aquecimento no volante",
           "has_window_control": "Controlo das janelas (abrir/fechar/ventilar)",
           "battery_capacity_override_kwh": "Substituição da capacidade útil da bateria (kWh)",
+          "fuel_tank_override_litres": "Substituição da capacidade do depósito de combustível (litros)",
           "enable_shutdown_refresh_sequence": "Ativar sequência de atualização pós-desligamento",
           "abrp_user_token": "Token de utilizador ABRP",
           "abrp_api_key": "Chave de API do ABRP"
@@ -401,6 +402,7 @@
         "title": "Opções MG/SAIC",
         "data_description": {
           "battery_capacity_override_kwh": "Capacidade útil da bateria do seu carro em kWh. Substitui o valor interno usado no sensor de capacidade total da bateria e nos cálculos de eficiência e energia das viagens — use se a capacidade do seu modelo for indicada incorretamente. Deixe em branco para usar o valor automático.",
+          "fuel_tank_override_litres": "A capacidade do depósito de combustível do seu carro em litros. Usada para os valores de litros, L/100 km e mpg nos sensores de viagem. A capacidade do depósito varia consoante o mercado para o mesmo modelo, por isso defina-a se os valores de combustível parecerem errados para o seu carro. Deixe em branco para usar o valor integrado.",
           "abrp_user_token": "Cole o token de utilizador da aplicação ABRP (Definições → o seu carro → Live Data → Generic) para enviar os dados deste veículo para o A Better Route Planner. Também precisa da sua própria chave de API (abaixo); ambas são obrigatórias. Deixe ambas em branco para desativar. Consulte {abrp_doc_url}.",
           "abrp_api_key": "Introduza a sua própria chave de API da Iternio, criada no portal de programadores da Iternio — consulte {abrp_doc_url}. Obrigatória juntamente com o token de utilizador para ativar o ABRP."
         }
@@ -412,7 +414,9 @@
       "abrp_no_api_key": "Introduza a sua chave de API do ABRP além do token de utilizador — ambos são obrigatórios para ativar o ABRP.",
       "abrp_unknown": "Erro inesperado ao validar o token ABRP.",
       "capacity_invalid": "Introduza um número para a capacidade da bateria (kWh) ou deixe em branco.",
-      "capacity_out_of_range": "A capacidade da bateria deve estar entre 1 e 250 kWh."
+      "tank_invalid": "Introduza um número para a capacidade do depósito (litros) ou deixe em branco.",
+      "capacity_out_of_range": "A capacidade da bateria deve estar entre 1 e 250 kWh.",
+      "tank_out_of_range": "A capacidade do depósito deve estar entre 1 e 200 litros."
     }
   },
   "entity": {

--- a/custom_components/mg_saic/trip_stats.py
+++ b/custom_components/mg_saic/trip_stats.py
@@ -456,6 +456,11 @@ def compute_completed_trip(
         else:
             trip["fuel_used_pct"] = fuel_used
             if tank_litres:
+                # Surfaced so an owner can see which tank size produced these
+                # figures without digging through options — tank sizes are
+                # market-split for the same model, so "is it using mine?" is a
+                # reasonable question to be able to answer (#354).
+                trip["fuel_tank_litres"] = tank_litres
                 litres = round(fuel_used / 100.0 * tank_litres, 2)
                 trip["fuel_used_litres"] = litres
                 if litres > 0:

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -327,3 +327,5 @@ The **Fuel tank size override (litres)** option (under **Configure**) lets you s
 The trip sensors carry a `fuel_tank_litres` attribute showing which tank size actually produced the figures, so you can confirm your override is in use without digging through options.
 
 If your fuel figures look implausible — an unrealistically good mpg is the usual sign, since too small a tank understates the litres used — this is the setting to check. There are only two tiers here (override, then our figure), so if neither has a value the fuel sensors report **% used** but not litres, L/100km or mpg.
+
+Both override fields are shown to every vehicle, since the options form isn't filtered by vehicle type. **If you drive a BEV you can safely ignore the fuel tank field** — setting it has no effect, because nothing on a battery-electric car computes fuel figures. The same applies in reverse: the battery capacity field is shown to ICE owners and is equally inert there.

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -317,3 +317,13 @@ The **Usable battery capacity override (kWh)** option (under **Configure**) lets
 The Total Battery Capacity sensor carries a `capacity_source` attribute (`user_override`, `profile`, or `api`) so you can see — and template off — exactly where the displayed figure came from. The same resolved figure feeds every energy calculation derived from capacity, so the displayed pack size and the sensors derived from it can't disagree.
 
 Where a car reports a capacity that can't be trusted, none is used: the `totalBatteryCapacity=725` placeholder (→ 72.5 kWh) is rejected outright, as is anything outside 5–200 kWh. On such a car with no profile figure and no override, Total Battery Capacity reads blank and `capacity_source` is absent, rather than showing a number the car invented and deriving charge and efficiency figures from it. Setting a [battery capacity override](#battery-capacity-override) is the fix if you know your real capacity.
+
+### Fuel tank size override
+
+Petrol tank sizes are market-split for the same model — the MG HS PHEV is documented at 37 L in some markets while owners of 2025/26 UK cars report filling considerably more — and unlike battery capacity, **the API reports no tank size at all**, so there's nothing to cross-check our per-model figure against.
+
+The **Fuel tank size override (litres)** option (under **Configure**) lets you set your car's tank size yourself. When set, it takes priority over our built-in per-model figure and becomes the basis for every fuel figure derived from it: `fuel_used_litres`, `fuel_consumption_L_per_100km`, and both mpg figures on the trip sensors. The `fuel_used_pct` figure comes straight from the car and is unaffected either way. Leave it blank to go back to the built-in value; saving takes effect immediately.
+
+The trip sensors carry a `fuel_tank_litres` attribute showing which tank size actually produced the figures, so you can confirm your override is in use without digging through options.
+
+If your fuel figures look implausible — an unrealistically good mpg is the usual sign, since too small a tank understates the litres used — this is the setting to check. There are only two tiers here (override, then our figure), so if neither has a value the fuel sensors report **% used** but not litres, L/100km or mpg.

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -251,9 +251,31 @@ class ElectricRangeKmTests(unittest.TestCase):
         charging = SimpleNamespace(rvsChargeStatus=SimpleNamespace(fuelRangeElec=-128))
         self.assertEqual(self._range(basic, charging), 53.0)
 
-    def test_zero_range_is_a_real_value(self):
-        # A flat pack genuinely has no range left; that is not missing data.
-        self.assertEqual(self._range(SimpleNamespace(fuelRangeElec=0)), 0.0)
+    def test_zero_fuel_range_elec_falls_through_to_imcu(self):
+        """0 means "not reported", not "no range left" (#354).
+
+        @HarryFlatter's charge log: rvsChargeStatus.fuelRangeElec sat at 0
+        for an entire charge while imcuVehElecRng climbed 75 -> 120 km.
+        Accepting that 0 short-circuits the fallback and hands every caller a
+        range of zero, which broke the range-after-charging projection and
+        made Last Charge Range Added read 0.0 against a ~28 mile charge.
+        """
+        charging = SimpleNamespace(
+            rvsChargeStatus=SimpleNamespace(fuelRangeElec=0),
+            chrgMgmtData=SimpleNamespace(imcuVehElecRng=75),
+        )
+        self.assertEqual(
+            self._range(SimpleNamespace(fuelRangeElec=-128), charging), 75.0
+        )
+
+    def test_zero_everywhere_is_unknown_not_zero(self):
+        """With no usable source at all, None is more honest than a 0 that
+        silently breaks every calculation downstream."""
+        charging = SimpleNamespace(
+            rvsChargeStatus=SimpleNamespace(fuelRangeElec=0),
+            chrgMgmtData=SimpleNamespace(imcuVehElecRng=0),
+        )
+        self.assertIsNone(self._range(SimpleNamespace(fuelRangeElec=0), charging))
 
     def test_falls_back_to_imcu_vehicle_range(self):
         """Models flagged reliable_fuel_range_elec: False never give a usable
@@ -448,6 +470,44 @@ class AddedElectricRangeScaleTests(unittest.TestCase):
             "Added Electric Range must not use the tenths correction — the car "
             "reports whole kilometres (#326)",
         )
+
+
+class ResolveFuelTankLitresTests(unittest.TestCase):
+    """Tank size precedence: user override > our per-model figure (#354).
+
+    Unlike battery capacity there is no third API tier — SAIC reports no
+    tank size at all — so a user override is the only way to correct a model
+    whose tank size is market-split.
+    """
+
+    def test_override_wins(self):
+        self.assertEqual(
+            LOGIC.resolve_fuel_tank_litres(55.0, 37.0), (55.0, "user_override")
+        )
+
+    def test_profile_used_when_no_override(self):
+        self.assertEqual(
+            LOGIC.resolve_fuel_tank_litres(None, 37.0), (37.0, "profile")
+        )
+
+    def test_nothing_available(self):
+        self.assertEqual(LOGIC.resolve_fuel_tank_litres(None, None), (None, None))
+
+    def test_override_works_with_no_profile_figure(self):
+        # An unprofiled ICE model: the override is the only source there is.
+        self.assertEqual(
+            LOGIC.resolve_fuel_tank_litres(50.0, None), (50.0, "user_override")
+        )
+
+    def test_harrys_numbers(self):
+        """@HarryFlatter's HS PHEV: 19% used reported as 7.03 L against our
+        37 L figure. With his 55 L override the same 19% is 10.45 L, which
+        over his 209 km trip is ~5.0 L/100km (≈56 mpg) rather than
+        ≈84 mpg — the more plausible figure for a trip that used almost no
+        battery."""
+        litres, source = LOGIC.resolve_fuel_tank_litres(55.0, 37.0)
+        self.assertEqual(source, "user_override")
+        self.assertAlmostEqual(19.0 / 100.0 * litres, 10.45, places=2)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_and_config_flow.py
+++ b/tests/test_setup_and_config_flow.py
@@ -1194,6 +1194,40 @@ class TestNoVehiclesSetupMessage(unittest.TestCase):
                 msg=f"{lang}.json is missing config.error.no_vehicles",
             )
 
+    def test_every_language_file_has_the_same_keys(self):
+        """Generalises the check above to the whole file (#354).
+
+        The fuel tank override shipped English-only on its first pass and
+        only got caught by review — a user on another language would have
+        seen a raw key like `fuel_tank_override_litres` as the field label.
+        This makes that a test failure rather than something to spot by eye
+        next time an option is added.
+        """
+        import json
+
+        def keys(obj, prefix=""):
+            found = set()
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    found.add(prefix + k)
+                    found |= keys(v, prefix + k + ".")
+            return found
+
+        base = Path(CF.__file__).resolve().parent / "translations"
+        english = keys(json.load(open(base / "en.json", encoding="utf-8")))
+        for lang in ("es", "fr", "pt"):
+            other = keys(json.load(open(base / f"{lang}.json", encoding="utf-8")))
+            self.assertEqual(
+                english - other,
+                set(),
+                msg=f"{lang}.json is missing keys present in en.json",
+            )
+            self.assertEqual(
+                other - english,
+                set(),
+                msg=f"{lang}.json has keys that en.json doesn't",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two changes from @HarryFlatter's charge log and follow-up (#354).

## Part 1: one root cause behind both of his blank sensors

His full charge log settles it. Across the entire session:

```
rvsChargeStatus.fuelRangeElec     0     (all 10 polls)
basicVehicleStatus.fuelRangeElec  -128  (sentinel, correctly rejected)
imcuVehElecRng                    75 -> 120 km (real, climbing)
```

`electric_range_km` accepted `raw >= 0`, so the `0` from `rvsChargeStatus` was taken as a valid "no range left" reading and returned immediately — short-circuiting the `imcuVehElecRng` fallback that was added for exactly this model. **Every caller got a range of zero.**

That single fault produced both symptoms he reported:

- **ERAC blank** — `project_range_at_target` rejects a non-positive `current_range` and returns `None`.
- **"Last Charge Range Added: 0.0 mi"** — the charge-session range delta computed `0 - 0 = 0` against a charge that really added ~28 miles (75 → 120 km).

Fixed by treating `0` as "not reported" (`raw > 0`). A car genuinely at zero range loses nothing: the imcu fallback answers instead, and if that's absent too, `None` is more honest than a zero that silently breaks everything downstream.

**The test asserting 0 was a real value was written on my assumption, and his log disproved it** — replaced with tests reflecting the actual observed behaviour.

Sanity check on his numbers: at 63.5% SOC with 75 km showing, projecting to a full charge gives ~118 km. The charge actually finished at 120 km.

## Part 2: fuel tank size override

Tank sizes are market-split for the same model, and **the API reports no tank size at all** — so unlike battery capacity there's nothing to cross-check our per-model figure against, and no way for an owner to correct it.

Adds **Fuel tank size override (litres)** under Configure, mirroring the battery capacity override: text field, blank clears, validated 1–200 L, applied immediately on save without a reload. `resolve_fuel_tank_litres` returns `(litres, source)` with **two** tiers — `user_override` > `profile` — since there's no API tier to add.

Trip dicts now carry `fuel_tank_litres` (the size actually used) so an owner can confirm their override is in effect without digging through options.

### Deliberately NOT changing the AS33P profile from 37 L

The evidence for 55 L is an owner's recollection plus ChatGPT output and MG literature however that literature is only correct for recent version of the same car; older cars of the same model have a lower fuel tank capacity — not a source I'd change a shipped default on, since it would silently alter every existing HS PHEV owner's fuel figures. The override lets Harry fix his own car today, and if more UK owners confirm 55 L the profile can follow on real evidence.

Worth noting his numbers do lean that way: 19% at 37 L gives ~84 mpg over that trip, which isn't plausible for a 1.9 t SUV that used almost no battery; at 55 L it's ~56 mpg.

## Testing

8 new/updated tests. `en.json` updated; es/fr/pt fall back to English for the new keys as usual. 317 pass, pyflakes clean. `docs/sensors.md` updated. Version `1.2.9-beta3`.