### PR TITLE
docs: correct the Max Cool / app-button claim (#336, @MarcThu)

### DIFF
--- a/custom_components/mg_saic/const.py
+++ b/custom_components/mg_saic/const.py
@@ -360,8 +360,19 @@ VEHICLE_PROFILES = {
         "climate_mode_defrost": 5,
         "cool_uses_start_ac": True,    # mode 2 is ambiguous -- see notes above
         # Max Cool also pins the setpoint to the profile minimum, on top of
-        # using the genuinely stronger mode 3 -- belt and braces, and matches
-        # the iSmart app's one-tap LOW-cool button (#243).
+        # using the genuinely stronger mode 3 -- belt and braces.
+        #
+        # CORRECTION (#336): an earlier version of this comment claimed Max
+        # Cool matches the app's one-tap LOW-cool button. It doesn't.
+        # @MarcThu checked directly -- the app's dedicated LOW and HIGH
+        # buttons both report mode 2 (same as the slider), never mode 3:
+        #   LOW:  remoteClimateStatus previous=0, current=2
+        #   HIGH: remoteClimateStatus previous=0, current=2
+        # So mode 3, while genuinely real and confirmed cool-only (#243), does
+        # not appear to be reachable through any control the app itself
+        # offers -- Max Cool is a capability this integration adds beyond
+        # what the app can do, the same way the Defrost preset already is,
+        # not a mirror of an existing app feature.
         "max_cool_forces_min_temp": True,
         "climate_status_fan_only": {1},
         "climate_status_cool": {3},    # only the UNAMBIGUOUS cool-only mode

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -104,7 +104,7 @@ On these models there is **no fan-speed slider** — the car manages its own fan
 | HVAC `Heat` | Heating |
 | HVAC `Fan Only` | Fan without the compressor |
 | HVAC `Off` | Stops all climate activity |
-| Preset `Max Cool` | The strongest cooling the car has, ignoring whatever temperature is set — on the MG4 EV URBAN this is a genuinely different, stronger mode from ordinary `Cool`, not just the same mode with a lower setpoint; it also drops the temperature to the lowest setting in a single tap |
+| Preset `Max Cool` | The strongest cooling the car has, ignoring whatever temperature is set — on the MG4 EV URBAN this is a genuinely different, stronger mode from ordinary `Cool`, not just the same mode with a lower setpoint; it also drops the temperature to the lowest setting in a single tap. Confirmed not reachable through any control the iSmart app itself offers (#336) — like Defrost below, it's a capability this integration adds rather than a mirror of an existing app button |
 | Preset `Defrost` | Windscreen / upper-vent defrost |
  
 > **Note:** not every mode-select car offers all of these. `Heat` and the `Defrost` preset are only shown on models that actually support them.


### PR DESCRIPTION
Small follow-up to #359, already merged and released as 1.2.9-beta4.

## What's wrong

That PR's profile comment claimed Max Cool (mode 3) mirrors the iSmart app's one-tap LOW-cool button. @MarcThu checked directly and it doesn't — the app's dedicated LOW and HIGH buttons both report mode 2, same as the manual slider:

```
LOW:  remoteClimateStatus previous=0, current=2
HIGH: remoteClimateStatus previous=0, current=2
```

Mode 3's own behaviour isn't in question — it's still real and confirmed cool-only (#243). Only the claim that the app uses it anywhere turns out to be wrong.

## What changed

Corrected the profile comment with the actual evidence, and gave Max Cool the same "capability this integration adds, not a mirror of an app feature" framing that Defrost already carries in `docs/controls.md` — the two read consistently now, and if anything Max Cool comes out as a bigger win for URBAN owners than a coincidental match to something the app already had.

## What I deliberately did NOT change

Looked seriously at whether `_send_climate_command`'s ordering (network call before the `requested_hvac_mode` tracking update) has a real timing gap, prompted by a separate report from MarcThu of heat being set but cool showing after a sync. Concluded no code change is warranted here:

- Moving the tracking update earlier would mean a **failed** send (network blip, rate limit) leaves the UI confidently showing the new mode anyway, since `async_set_hvac_mode`'s exception handler never rolls state back. That's a worse bug than the one it would close.
- The original window isn't actually wrong in practice either: a poll landing mid-send sees the car's pre-command status alongside the pre-command tracked intent — consistently stale together, not mismatched — and self-corrects on the very next poll regardless.

MarcThu's report is far more likely explained by heat having been set through the app rather than through Home Assistant, which our tracking has no way to observe — asked him directly to confirm which, on the original PR/issue thread.

No functional code change. 323 tests pass, pyflakes clean.