### PR TITLE
fix: Battery Energy ignored the capacity override (#371, @SteveMSJ)

### DIFF
--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.2.0"
   ],
-  "version": "1.2.9-beta8"
+  "version": "1.2.9-beta9"
 }

--- a/custom_components/mg_saic/sensor.py
+++ b/custom_components/mg_saic/sensor.py
@@ -3443,23 +3443,37 @@ class SAICMGEfficiencySinceChargeSensor(CoordinatorEntity, SensorEntity):
 class SAICMGBatteryEnergySensor(CoordinatorEntity, SensorEntity):
     """Energy currently held in the battery, in kWh.
 
-    Two sources, in order:
+    Two sources, in this order:
 
-    1. The car's own figures. India reports pack energy outright; elsewhere it
-       is reconstructed as ``lastChargeEndingPower - powerUsageSinceLastCharge``
-       -- what the pack held when the last charge ended, minus what has been
-       taken out since. Both are real API fields, so this is the car's own
-       accounting rather than our arithmetic.
-    2. Failing that, SOC% x usable capacity. Needed because some cars never
-       populate lastChargeEndingPower at all (the MG HS PHEV reports it as
-       None), which would otherwise leave this permanently blank on exactly
-       the cars that already have the least charging telemetry.
+    1. SOC% x the resolved usable capacity, whenever we have a capacity we
+       trust (a user override or our per-model profile).
+    2. The car's own pack-energy figure, when we have no capacity at all.
 
-    The ``source`` attribute says which was used: ``reported`` or
-    ``estimated``. They will not always agree -- the reported route inherits
-    whatever drift is in the car's own counters, while the estimated route
-    inherits the usable-capacity figure and the coarseness of SOC -- so the
-    attribute matters if the number ever looks off.
+    That order is deliberate, and it is the REVERSE of how this sensor
+    originally shipped. Preferring the car's figure looked obviously right --
+    the car ought to know its own pack better than we do -- but @SteveMSJ
+    showed (#371) that on the cars where it matters, it doesn't:
+
+        MG4 Trophy LR: SOC 72.7%, reported 52.70 kWh. 52.70 / 0.727 = 72.5,
+        exactly the API's placeholder capacity, NOT the owner's 61.7 kWh
+        override.
+
+        MGS6: SOC 74.8%, reported 54.3 kWh, implying 72.6 kWh against a
+        profile capacity of 74.3.
+
+    So the reported figure behaves as SOC x a nominal pack size the car holds
+    internally, rather than an independent BMS measurement. It therefore adds
+    no information the SOC does not already carry, while inheriting a capacity
+    we have specifically decided not to trust -- and it did so silently, since
+    ``source: reported`` reads as authoritative. Preferring it defeated the
+    battery capacity override, which exists precisely to correct that number.
+
+    The reported route is kept for the case where it IS the only real source:
+    India-region cars report genuine pack energy in kWh from the BMS and carry
+    no capacity field at all, so there is nothing to calculate from there.
+
+    The ``source`` attribute says which was used: ``estimated`` or
+    ``reported``.
     """
 
     def __init__(self, coordinator, entry):
@@ -3486,12 +3500,9 @@ class SAICMGBatteryEnergySensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         charging_data = (self.coordinator.data or {}).get("charging")
-        reported = self.coordinator._extract_pack_energy_kwh(charging_data)
-        if reported is not None and reported >= 0:
-            self._source = "reported"
-            return round(reported, 3)
 
-        # Fallback: SOC x usable capacity.
+        # Preferred: SOC x the capacity we resolved, so a capacity override or
+        # profile figure actually governs this sensor (#371).
         # NB: _extract_soc_pct takes basicVehicleStatus, NOT the top-level
         # status object. Passing the latter silently loses the extendedData1
         # fallback inside it, so a charging-endpoint dropout would blank this
@@ -3501,11 +3512,20 @@ class SAICMGBatteryEnergySensor(CoordinatorEntity, SensorEntity):
         basic_status = getattr(status, "basicVehicleStatus", None)
         soc = self.coordinator._extract_soc_pct(basic_status, charging_data)
         capacity = self.coordinator.effective_battery_capacity_kwh
-        if soc is None or not capacity:
-            self._source = None
-            return None
-        self._source = "estimated"
-        return round(soc / 100.0 * capacity, 3)
+        if soc is not None and capacity:
+            self._source = "estimated"
+            return round(soc / 100.0 * capacity, 3)
+
+        # No capacity to calculate from (an unprofiled car with no override,
+        # or India, whose frames carry no capacity field). The car's own
+        # pack-energy figure is then the only source there is.
+        reported = self.coordinator._extract_pack_energy_kwh(charging_data)
+        if reported is not None and reported >= 0:
+            self._source = "reported"
+            return round(reported, 3)
+
+        self._source = None
+        return None
 
     @property
     def extra_state_attributes(self):

--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -68,7 +68,7 @@ The MG/SAIC Custom Integration provides the following sensors, binary sensors, a
 - Last Trip Efficiency *(BEV/PHEV; switchable km/kWh · mi/kWh · kWh/100km, full breakdown in attributes)*
 - Last Trip Fuel Economy *(ICE/HEV/PHEV; L/100km, with the full breakdown in its attributes)*
 - Total Battery Capacity *(kWh; corrected for models where the API reports an inaccurate value, and can be overridden per vehicle — see [Battery capacity override](#battery-capacity-override))*
-- Battery Energy *(kWh; how much energy is in the battery right now — the car's own figure where it reports one, otherwise battery percentage × usable capacity. A `source` attribute says which: `reported` or `estimated`)*
+- Battery Energy *(kWh; how much energy is in the battery right now — battery percentage × usable capacity, falling back to the car's own pack-energy figure only where no capacity is known. A `source` attribute says which: `estimated` or `reported` — see [Battery Energy and capacity](#battery-energy-and-capacity))*
 - Battery Heating Status *(if equipped)*
 - Reachability *(is the car awake / likely asleep / unreachable — see [Deep sleep & holiday mode](power-management.md#deep-sleep--holiday-mode))*
 - Data Freshness *(diagnostic: whether the last poll returned `live`, `cached` or `failed` data — see [Data Freshness sensor](power-management.md#data-freshness-sensor))*
@@ -381,6 +381,16 @@ The **Usable battery capacity override (kWh)** option (under **Configure**) lets
 The Total Battery Capacity sensor carries a `capacity_source` attribute (`user_override`, `profile`, or `api`) so you can see — and template off — exactly where the displayed figure came from. The same resolved figure feeds every energy calculation derived from capacity, so the displayed pack size and the sensors derived from it can't disagree.
 
 Where a car reports a capacity that can't be trusted, none is used: the `totalBatteryCapacity=725` placeholder (→ 72.5 kWh) is rejected outright, as is anything outside 5–200 kWh. On such a car with no profile figure and no override, Total Battery Capacity reads blank and `capacity_source` is absent, rather than showing a number the car invented and deriving charge and efficiency figures from it. Setting a [battery capacity override](#battery-capacity-override) is the fix if you know your real capacity.
+
+### Battery Energy and capacity
+
+**Battery Energy** is calculated as battery percentage × the usable capacity resolved above, so a [battery capacity override](#battery-capacity-override) governs it directly. The `source` attribute reads `estimated` in that case.
+
+It only falls back to the car's own reported pack-energy figure — `source: reported` — where no capacity is available at all: an unprofiled model with no override, or an India-region car, whose charging frames carry real BMS pack energy in kWh but no capacity field to calculate from.
+
+That order is deliberate, and it changed in **1.2.9-beta9**. The sensor originally preferred the car's reported figure, on the reasonable-sounding basis that the car knows its own pack. In practice it doesn't: on the models where it matters, that figure behaves as battery percentage × a nominal pack size held internally by the car, not as an independent BMS measurement. An MG4 Trophy LR reporting 52.70 kWh at 72.7% implies 72.5 kWh — the API's known-wrong placeholder — rather than the owner's 61.7 kWh override. So the reported figure added nothing the percentage didn't already give, while quietly inheriting the very capacity the override exists to correct.
+
+If you have a capacity override set and this sensor still reads `reported`, that means the override isn't being picked up — worth checking it's saved correctly.
 
 ### Fuel tank size override
 

--- a/tests/test_erac_fallback.py
+++ b/tests/test_erac_fallback.py
@@ -288,12 +288,30 @@ class BatteryEnergyTests(unittest.TestCase):
         entry = SimpleNamespace(entry_id="e1")
         return SENSOR.SAICMGBatteryEnergySensor(coordinator, entry)
 
-    def test_prefers_the_cars_own_figure(self):
+    def test_prefers_the_trusted_capacity_over_the_cars_own_figure(self):
+        """#371: the car's reported energy is SOC x a nominal capacity it
+        holds internally, so preferring it silently defeated the capacity
+        override. The resolved capacity wins whenever we have one."""
         s = self._sensor(pack_energy=41.235, soc=80.0, capacity=64.0)
-        self.assertEqual(s.native_value, 41.235)
+        self.assertAlmostEqual(s.native_value, 51.2, places=3)
+        self.assertEqual(s.extra_state_attributes["source"], "estimated")
+
+    def test_steves_mg4_uses_his_override_not_the_api_capacity(self):
+        """His real numbers: SOC 72.7%, the car reporting 52.70 kWh (= 72.5,
+        the API placeholder), against a 61.7 kWh override. The override must
+        govern."""
+        s = self._sensor(pack_energy=52.70, soc=72.7, capacity=61.7)
+        self.assertAlmostEqual(s.native_value, 44.85, places=1)
+        self.assertEqual(s.extra_state_attributes["source"], "estimated")
+        self.assertNotAlmostEqual(s.native_value, 52.70, places=1)
+
+    def test_reported_used_when_there_is_no_capacity_to_calculate_from(self):
+        """India: real BMS pack energy, and no capacity field at all."""
+        s = self._sensor(pack_energy=37.4, soc=80.0, capacity=None)
+        self.assertEqual(s.native_value, 37.4)
         self.assertEqual(s.extra_state_attributes["source"], "reported")
 
-    def test_falls_back_to_soc_times_capacity(self):
+    def test_works_with_no_reported_figure_at_all(self):
         """The HS PHEV case: no lastChargeEndingPower, so nothing to report."""
         s = self._sensor(pack_energy=None, soc=50.0, capacity=23.2)
         self.assertAlmostEqual(s.native_value, 11.6, places=3)
@@ -305,13 +323,21 @@ class BatteryEnergyTests(unittest.TestCase):
         self.assertIsNone(s.extra_state_attributes)
         self.assertFalse(s.available)
 
-    def test_unknown_without_a_capacity_to_estimate_from(self):
-        """An unprofiled car with no override: blank beats a wrong number."""
+    def test_unknown_with_neither_a_capacity_nor_a_reported_figure(self):
+        """An unprofiled car with no override and nothing reported: blank
+        beats a wrong number."""
         s = self._sensor(pack_energy=None, soc=80.0, capacity=None)
         self.assertIsNone(s.native_value)
 
     def test_reports_zero_rather_than_treating_it_as_missing(self):
+        # Flat pack, capacity known: calculated route gives a genuine 0.0.
         s = self._sensor(pack_energy=0.0, soc=0.0, capacity=64.0)
+        self.assertEqual(s.native_value, 0.0)
+        self.assertEqual(s.extra_state_attributes["source"], "estimated")
+
+        # Flat pack, no capacity: the reported 0.0 must not be mistaken for
+        # missing data and blank the sensor.
+        s = self._sensor(pack_energy=0.0, soc=None, capacity=None)
         self.assertEqual(s.native_value, 0.0)
         self.assertEqual(s.extra_state_attributes["source"], "reported")
 


### PR DESCRIPTION
The sensor preferred the car's own reported pack energy over calculating from SOC. That looked obviously right -- the car ought to know its own pack -- and it is wrong on exactly the cars where it matters.

@SteveMSJ's MG4 Trophy LR: SOC 72.7%, reported 52.70 kWh. 52.70 / 0.727 = 72.5, precisely the API's placeholder capacity, NOT his 61.7 kWh override. Checked against a second car for confirmation -- James's MGS6: SOC 74.8%, reported 54.3 kWh, implying 72.6 against a profile capacity of 74.3. Two cars, two different capacity sources, same result.

So the reported figure is SOC x a nominal pack size the car holds internally, not an independent BMS measurement. It carries no information the SOC does not already give, while inheriting a capacity we have specifically decided not to trust -- and it did so silently, because "source: reported" reads as authoritative when it was the less trustworthy of the two. Preferring it defeated the battery capacity override, whose entire purpose is correcting that number.

Priority is now inverted: SOC x resolved capacity whenever a capacity is available (override or profile), falling back to the reported figure only when there is no capacity at all. That keeps the reported route for the case where it is genuinely the only source -- India frames carry real BMS pack energy in kWh and no capacity field to calculate from.

Effect on the two cars above: Steve's MG4 goes 52.70 -> 44.86 kWh (72.7% x 61.7), James's MGS6 54.3 -> 55.58 (74.8% x 74.3). Anyone currently seeing "reported" with a capacity set will see their figure move; it needs calling out in the release notes rather than looking like a new bug.

3 tests added including Steve's real numbers and the India-shaped case, and the zero case now covers both routes -- a reported 0.0 with no capacity must still publish 0.0 rather than blanking. Existing tests that asserted the old priority updated. 368 tests pass, pyflakes clean.

docs/sensors.md gains a "Battery Energy and capacity" section explaining the order, why it changed, and what it means if the sensor still reads "reported" with an override set. Version 1.2.9-beta9.