### PR TITLE
fix: persist GPS location across HA restarts (#375)

### DIFF
--- a/custom_components/mg_saic/device_tracker.py
+++ b/custom_components/mg_saic/device_tracker.py
@@ -1,6 +1,7 @@
 # File: device_tracker.py
 
 from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, LOGGER
 from .utils import create_device_info
@@ -24,7 +25,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         LOGGER.error("Error setting up MG SAIC device tracker: %s", e)
 
 
-class SAICMGDeviceTracker(CoordinatorEntity, TrackerEntity):
+class SAICMGDeviceTracker(CoordinatorEntity, RestoreEntity, TrackerEntity):
     """Representation of a MG SAIC device tracker."""
 
     def __init__(self, coordinator, entry, field, name, data_type):
@@ -41,6 +42,35 @@ class SAICMGDeviceTracker(CoordinatorEntity, TrackerEntity):
         self._last_lat = None
         self._last_lon = None
         self._last_valid_heading = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known-good position after a restart (#375).
+
+        The SAIC API can report 0,0 on the very first poll of a new session
+        (or whenever the car has no fix, e.g. parked in a garage), and the
+        in-memory fallback above only helps once a real fix has been seen
+        THIS session -- on a fresh restart it starts out empty, so a 0,0
+        first poll was shown as-is. Restoring from the entity's last
+        recorded state seeds the fallback before the first coordinator
+        update after startup.
+        """
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+
+        try:
+            lat = last_state.attributes.get("latitude")
+            lon = last_state.attributes.get("longitude")
+            if lat is not None and lon is not None:
+                self._last_lat = float(lat)
+                self._last_lon = float(lon)
+        except (TypeError, ValueError):
+            LOGGER.debug(
+                "Could not restore last known GPS position for %s",
+                self.entity_id,
+            )
 
     @property
     def unique_id(self):

--- a/custom_components/mg_saic/manifest.json
+++ b/custom_components/mg_saic/manifest.json
@@ -15,5 +15,5 @@
     "mg-saic-client==0.9.4",
     "mg-ismart-india-client==0.2.0"
   ],
-  "version": "1.2.9-beta9"
+  "version": "1.2.9-beta10"
 }

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -1,0 +1,234 @@
+"""Regression coverage for the GPS device tracker (#375).
+
+The SAIC API can report 0,0 coordinates on the very first poll of a new HA
+session (or whenever the car has no GPS fix, e.g. parked in a garage). The
+tracker already falls back to the last known-good position it has seen, but
+that fallback lived only in memory -- a fresh restart started with nothing
+to fall back to, so a 0,0 first poll went straight to the entity. This
+verifies the entity now restores its last known-good position from Home
+Assistant's restore-state cache before the first coordinator update lands.
+"""
+
+import asyncio
+import importlib.util
+import logging
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG_DIR = REPO_ROOT / "custom_components" / "mg_saic"
+PACKAGE = "mg_saic_device_tracker_test"
+LOADED_MODULE_NAMES = (
+    "homeassistant",
+    "homeassistant.components",
+    "homeassistant.components.device_tracker",
+    "homeassistant.helpers",
+    "homeassistant.helpers.restore_state",
+    "homeassistant.helpers.update_coordinator",
+    PACKAGE,
+    f"{PACKAGE}.const",
+    f"{PACKAGE}.utils",
+    f"{PACKAGE}.device_tracker",
+)
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+class _RestoredState:
+    def __init__(self, attributes):
+        self.attributes = attributes
+
+
+class _RestoreEntity:
+    """Stand-in for homeassistant.helpers.restore_state.RestoreEntity.
+
+    Tests set ``_test_last_state`` on the instance before calling
+    ``async_added_to_hass`` to control what "last known state" looks like,
+    mirroring how the real mixin surfaces the entity's last recorded state.
+    """
+
+    entity_id = None
+    _test_last_state = None
+
+    async def async_added_to_hass(self):
+        pass
+
+    async def async_get_last_state(self):
+        return self._test_last_state
+
+
+def _module(name, **attributes):
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_device_tracker():
+    previous_modules = {
+        name: sys.modules[name] for name in LOADED_MODULE_NAMES if name in sys.modules
+    }
+    try:
+        homeassistant = _module("homeassistant")
+        homeassistant.__path__ = []
+        components = _module("homeassistant.components")
+        components.__path__ = []
+        helpers = _module("homeassistant.helpers")
+        helpers.__path__ = []
+
+        class _TrackerEntity:
+            pass
+
+        _module(
+            "homeassistant.components.device_tracker", TrackerEntity=_TrackerEntity
+        )
+        _module(
+            "homeassistant.helpers.restore_state", RestoreEntity=_RestoreEntity
+        )
+        _module(
+            "homeassistant.helpers.update_coordinator",
+            CoordinatorEntity=_CoordinatorEntity,
+        )
+
+        package = _module(PACKAGE)
+        package.__path__ = [str(PKG_DIR)]
+        _module(
+            f"{PACKAGE}.const",
+            DOMAIN="mg_saic",
+            LOGGER=logging.getLogger(PACKAGE),
+        )
+        _module(f"{PACKAGE}.utils", create_device_info=lambda *_args: {})
+
+        return _load(f"{PACKAGE}.device_tracker", PKG_DIR / "device_tracker.py")
+    finally:
+        for name in LOADED_MODULE_NAMES:
+            if name in previous_modules:
+                sys.modules[name] = previous_modules[name]
+            else:
+                sys.modules.pop(name, None)
+
+
+DEVICE_TRACKER = _load_device_tracker()
+
+
+def _way_point(lat, lon, altitude=100, heading=90, speed=0, hdop=1, satellites=8):
+    return SimpleNamespace(
+        position=SimpleNamespace(
+            latitude=int(lat * 1e6), longitude=int(lon * 1e6), altitude=altitude
+        ),
+        heading=heading,
+        speed=speed,
+        hdop=hdop,
+        satellites=satellites,
+    )
+
+
+def _status(way_point):
+    gps_position = SimpleNamespace(wayPoint=way_point) if way_point else None
+    return SimpleNamespace(gpsPosition=gps_position)
+
+
+def _make_tracker(status):
+    vin_info = SimpleNamespace(vin="VIN1", brandName="MG", modelName="Test Vehicle")
+    coordinator = SimpleNamespace(
+        data={"status": status}, vin_info=vin_info, last_update_success=True
+    )
+    entry = SimpleNamespace(entry_id="entry-1")
+    return DEVICE_TRACKER.SAICMGDeviceTracker(
+        coordinator, entry, "gpsPosition", "GPS Location", data_type="status"
+    )
+
+
+class DeviceTrackerRestoreTests(unittest.TestCase):
+    def test_restores_last_known_position_when_first_poll_is_zero_zero(self):
+        # Simulate the exact #375 scenario: HA has just restarted, the
+        # coordinator's first poll reports 0,0 (no fix yet), but the entity
+        # previously recorded a real position before the restart.
+        tracker = _make_tracker(_status(_way_point(0.0, 0.0)))
+        tracker._test_last_state = _RestoredState(
+            {"latitude": 51.5074, "longitude": -0.1278}
+        )
+
+        asyncio.run(tracker.async_added_to_hass())
+
+        self.assertAlmostEqual(tracker.latitude, 51.5074)
+        self.assertAlmostEqual(tracker.longitude, -0.1278)
+
+    def test_fresh_fix_after_restore_overrides_the_restored_value(self):
+        tracker = _make_tracker(_status(_way_point(48.8566, 2.3522)))
+        tracker._test_last_state = _RestoredState(
+            {"latitude": 51.5074, "longitude": -0.1278}
+        )
+
+        asyncio.run(tracker.async_added_to_hass())
+
+        self.assertAlmostEqual(tracker.latitude, 48.8566)
+        self.assertAlmostEqual(tracker.longitude, 2.3522)
+
+    def test_no_previous_state_leaves_fallback_empty(self):
+        # Pre-existing behaviour (unaffected by the restore fix): the
+        # zero/zero -> last-known-good fallback only ever triggers once
+        # BOTH lat and lon have a stored fallback value. With nothing
+        # restored and no real fix seen yet this session, that never
+        # happens, so the raw (0.0, 0.0) the API reported passes through.
+        tracker = _make_tracker(_status(_way_point(0.0, 0.0)))
+        tracker._test_last_state = None
+
+        asyncio.run(tracker.async_added_to_hass())
+
+        self.assertEqual(tracker.latitude, 0.0)
+        self.assertEqual(tracker.longitude, 0.0)
+
+    def test_restored_state_missing_coordinates_leaves_fallback_empty(self):
+        tracker = _make_tracker(_status(_way_point(0.0, 0.0)))
+        tracker._test_last_state = _RestoredState({"source_type": "gps"})
+
+        asyncio.run(tracker.async_added_to_hass())
+
+        self.assertEqual(tracker.latitude, 0.0)
+        self.assertEqual(tracker.longitude, 0.0)
+
+    def test_malformed_restored_coordinates_are_ignored_not_fatal(self):
+        tracker = _make_tracker(_status(_way_point(0.0, 0.0)))
+        tracker._test_last_state = _RestoredState(
+            {"latitude": "unknown", "longitude": "unknown"}
+        )
+
+        # Should not raise, and should behave as if nothing was restored.
+        asyncio.run(tracker.async_added_to_hass())
+
+        self.assertEqual(tracker.latitude, 0.0)
+        self.assertEqual(tracker.longitude, 0.0)
+
+    def test_in_session_fallback_still_works_without_a_restart(self):
+        # Pre-existing behaviour (unaffected by the restore fix): once a
+        # real fix has been read for BOTH lat and lon this session, a
+        # later 0,0 poll still falls back to it.
+        tracker = _make_tracker(_status(_way_point(48.8566, 2.3522)))
+        asyncio.run(tracker.async_added_to_hass())
+        self.assertAlmostEqual(tracker.latitude, 48.8566)
+        self.assertAlmostEqual(tracker.longitude, 2.3522)
+
+        tracker.coordinator.data["status"] = _status(_way_point(0.0, 0.0))
+
+        self.assertAlmostEqual(tracker.latitude, 48.8566)
+        self.assertAlmostEqual(tracker.longitude, 2.3522)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_india_gps.py
+++ b/tests/test_india_gps.py
@@ -26,6 +26,7 @@ LOADED_MODULE_NAMES = (
     "homeassistant.const",
     "homeassistant.helpers",
     "homeassistant.helpers.entity",
+    "homeassistant.helpers.restore_state",
     "homeassistant.helpers.update_coordinator",
     "aiohttp",
     "mg_ismart_india_client",
@@ -91,6 +92,13 @@ def _load_modules():
         class _SensorEntity:
             pass
 
+        class _RestoreEntity:
+            async def async_added_to_hass(self):
+                pass
+
+            async def async_get_last_state(self):
+                return None
+
         class _ClientTimeout:
             def __init__(self, **_kwargs):
                 pass
@@ -139,6 +147,9 @@ def _load_modules():
             UnitOfTime=_Values,
         )
         _module("homeassistant.helpers.entity", EntityCategory=_Values)
+        _module(
+            "homeassistant.helpers.restore_state", RestoreEntity=_RestoreEntity
+        )
         _module(
             "homeassistant.helpers.update_coordinator",
             CoordinatorEntity=_CoordinatorEntity,


### PR DESCRIPTION
The GPS Location device tracker fell back to (0,0) coordinates on the first poll after a Home Assistant restart, or whenever the SAIC API briefly reports no fix (e.g. the car is in a garage). The existing zero-coordinate fallback only worked within a single running session, since the last known-good position was kept in a plain instance attribute that started empty on every restart.

The tracker now also inherits Home Assistant's RestoreEntity mixin and restores its last known latitude/longitude from the entity's previous state on async_added_to_hass, seeding the in-memory fallback before the first coordinator update of the new session can report a spurious (0,0). A fresh fix from a live poll still always takes precedence.

Adds tests/test_device_tracker.py covering the restart scenario.

Scope note: this is the same SAICMGDeviceTracker class the India backend feeds via its own GPS mapping (#289), so the restore fix applies there too with no India-side code change. However, tests/test_india_gps.py hand-stubs a minimal homeassistant module tree to import device_tracker.py in isolation, and does not yet stub the new homeassistant.helpers.restore_state import, so that test file will now fail to import until the India side updates its stub. Left untouched here deliberately -- global and India changes are kept separate; guidance for the India team provided out of band.

Bumps manifest version to 1.2.9-beta10.